### PR TITLE
Feature: Add rewind animation on level completion

### DIFF
--- a/app/src/main/java/com/appsters/unlimitedgames/games/maze/MazeGameActivity.kt
+++ b/app/src/main/java/com/appsters/unlimitedgames/games/maze/MazeGameActivity.kt
@@ -78,8 +78,10 @@ class MazeGameActivity : AppCompatActivity() {
         viewModel.isLevelComplete.observe(this) { isComplete ->
             if (isComplete) {
                 triggerConfetti()
-                mazeView.stopGame()
-                showUpgradeScreen(false)
+                mazeView.startRewind {
+                    mazeView.stopGame()
+                    showUpgradeScreen(false)
+                }
             }
         }
 


### PR DESCRIPTION
Adds a rewind animation when the player completes a maze level. The player character now visually retraces its path back to the start before the next level screen appears.

- Implemented a `replayBuffer` in `MazeView` to record the player's path.
- Added `startRewind()` and `updateRewind()` methods to control the animation playback.
- The player's position is updated from the `replayBuffer` during the rewind sequence.
- In `MazeGameActivity`, the level completion logic now triggers `mazeView.startRewind()` and waits for its completion callback before showing the upgrade screen.