### PR TITLE
Bug: Ensure clear all game data on logout and re-authenticate for email changes

### DIFF
--- a/app/src/main/java/com/appsters/unlimitedgames/app/MainActivity.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/app/MainActivity.java
@@ -20,9 +20,12 @@ import com.appsters.unlimitedgames.app.ui.auth.AuthViewModel;
 import com.appsters.unlimitedgames.app.ui.auth.AuthState;
 
 /**
- * The main activity of the application, serving as the primary entry point and navigation host.
- * This activity manages the overall application layout, including the toolbar and bottom navigation.
- * It observes the authentication state to dynamically switch between the main application content
+ * The main activity of the application, serving as the primary entry point and
+ * navigation host.
+ * This activity manages the overall application layout, including the toolbar
+ * and bottom navigation.
+ * It observes the authentication state to dynamically switch between the main
+ * application content
  * ({@code nav_main}) and the authentication flow ({@code nav_auth}).
  */
 public class MainActivity extends AppCompatActivity {
@@ -33,13 +36,18 @@ public class MainActivity extends AppCompatActivity {
     private AppBarConfiguration appBarConfiguration;
 
     /**
-     * Called when the activity is first created. This method initializes the view binding, sets up
-     * the action bar, and configures the navigation controller with top-level destinations.
-     * It also sets up an observer to monitor the authentication state and adjust the UI accordingly.
+     * Called when the activity is first created. This method initializes the view
+     * binding, sets up
+     * the action bar, and configures the navigation controller with top-level
+     * destinations.
+     * It also sets up an observer to monitor the authentication state and adjust
+     * the UI accordingly.
      *
      * @param savedInstanceState If the activity is being re-initialized after
-     *                           previously being shut down then this Bundle contains the data it most
-     *                           recently supplied in {@link #onSaveInstanceState}. Otherwise, it is null.
+     *                           previously being shut down then this Bundle
+     *                           contains the data it most
+     *                           recently supplied in {@link #onSaveInstanceState}.
+     *                           Otherwise, it is null.
      */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -59,7 +67,8 @@ public class MainActivity extends AppCompatActivity {
             navController = navHostFragment.getNavController();
 
             // Define top-level destinations for the AppBarConfiguration
-            appBarConfiguration = new AppBarConfiguration.Builder(R.id.homeFragment, R.id.friendsFragment, R.id.leaderboardFragment, R.id.profileFragment)
+            appBarConfiguration = new AppBarConfiguration.Builder(R.id.homeFragment, R.id.friendsFragment,
+                    R.id.leaderboardFragment, R.id.profileFragment)
                     .build();
 
             // Set up the toolbar with NavController and AppBarConfiguration
@@ -82,18 +91,22 @@ public class MainActivity extends AppCompatActivity {
     }
 
     /**
-     * Handles changes in the user's authentication state. It updates the navigation graph and the
-     * visibility of UI components like the toolbar and bottom navigation based on whether the user
+     * Handles changes in the user's authentication state. It updates the navigation
+     * graph and the
+     * visibility of UI components like the toolbar and bottom navigation based on
+     * whether the user
      * is authenticated, unauthenticated, or in a loading state.
      *
-     * @param authState The current authentication state (e.g., AUTHENTICATED, UNAUTHENTICATED).
+     * @param authState The current authentication state (e.g., AUTHENTICATED,
+     *                  UNAUTHENTICATED).
      */
     private void handleAuthState(AuthState authState) {
         switch (authState) {
             case LOADING:
                 // Hide UI elements during the loading process
                 binding.bottomNav.setVisibility(View.GONE);
-                if (getSupportActionBar() != null) getSupportActionBar().hide();
+                if (getSupportActionBar() != null)
+                    getSupportActionBar().hide();
                 break;
 
             case AUTHENTICATED:
@@ -102,8 +115,12 @@ public class MainActivity extends AppCompatActivity {
                     navController.setGraph(R.navigation.nav_main);
                 }
                 binding.bottomNav.setVisibility(View.VISIBLE);
-                if (getSupportActionBar() != null) getSupportActionBar().show();
+                if (getSupportActionBar() != null)
+                    getSupportActionBar().show();
                 setupBottomNavigation();
+
+                // Ensure Home is selected and highlighted
+                binding.bottomNav.setSelectedItemId(R.id.homeFragment);
                 break;
 
             case UNAUTHENTICATED:
@@ -112,7 +129,11 @@ public class MainActivity extends AppCompatActivity {
                     navController.setGraph(R.navigation.nav_auth);
                 }
                 binding.bottomNav.setVisibility(View.GONE);
-                if (getSupportActionBar() != null) getSupportActionBar().hide();
+                if (getSupportActionBar() != null)
+                    getSupportActionBar().hide();
+
+                // Clear all game data on logout
+                com.appsters.unlimitedgames.app.data.GameDataSource.clearAllGameData(this);
                 break;
 
             case ERROR:
@@ -123,9 +144,12 @@ public class MainActivity extends AppCompatActivity {
     }
 
     /**
-     * Sets up the listener for the bottom navigation view. This custom listener handles clicks on
-     * navigation items, ensuring that selecting an item either navigates to the destination or,
-     * if already in that destination's back stack, pops back to the root of that tab.
+     * Sets up the listener for the bottom navigation view. This custom listener
+     * handles clicks on
+     * navigation items, ensuring that selecting an item either navigates to the
+     * destination or,
+     * if already in that destination's back stack, pops back to the root of that
+     * tab.
      */
     private void setupBottomNavigation() {
         binding.bottomNav.setOnItemSelectedListener(item -> {
@@ -161,7 +185,8 @@ public class MainActivity extends AppCompatActivity {
     }
 
     /**
-     * Handles the Up button navigation. This is delegated to the NavController to ensure proper
+     * Handles the Up button navigation. This is delegated to the NavController to
+     * ensure proper
      * hierarchical navigation within the app.
      *
      * @return {@code true} if navigation was successful, {@code false} otherwise.
@@ -172,8 +197,10 @@ public class MainActivity extends AppCompatActivity {
     }
 
     /**
-     * Called when the activity is being destroyed. This is the final call that the activity
-     * receives. It cleans up resources by setting the view binding to null to prevent memory leaks.
+     * Called when the activity is being destroyed. This is the final call that the
+     * activity
+     * receives. It cleans up resources by setting the view binding to null to
+     * prevent memory leaks.
      */
     @Override
     protected void onDestroy() {

--- a/app/src/main/java/com/appsters/unlimitedgames/app/data/GameDataSource.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/app/data/GameDataSource.java
@@ -69,4 +69,23 @@ public class GameDataSource {
                                                 R.drawable.ic_maze));
                 return games;
         }
+
+        /**
+         * Clears all game data for all games.
+         *
+         * @param context The application context.
+         */
+        public static void clearAllGameData(android.content.Context context) {
+                // Clear Sudoku Data
+                new com.appsters.unlimitedgames.games.sudoku.repository.SudokuRepository(context).clearAllData();
+
+                // Clear Maze Data
+                com.appsters.unlimitedgames.games.maze.controller.RunManager.INSTANCE.clearAllData(context);
+
+                // Clear Whack-a-Mole Data
+                android.content.SharedPreferences whackPrefs = context.getSharedPreferences("WhackAMolePrefs",
+                                android.content.Context.MODE_PRIVATE);
+                new com.appsters.unlimitedgames.games.whackamole.repository.SharedPrefGameRepository(whackPrefs)
+                                .clearData();
+        }
 }

--- a/app/src/main/java/com/appsters/unlimitedgames/app/ui/profile/EditProfileFragment.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/app/ui/profile/EditProfileFragment.java
@@ -37,30 +37,39 @@ public class EditProfileFragment extends Fragment {
 
     /**
      * Inflates the fragment's layout.
-     * @param inflater The LayoutInflater object that can be used to inflate any views in the fragment.
-     * @param container If non-null, this is the parent view that the fragment's UI should be attached to.
-     * @param savedInstanceState If non-null, this fragment is being re-constructed from a previous saved state.
+     * 
+     * @param inflater           The LayoutInflater object that can be used to
+     *                           inflate any views in the fragment.
+     * @param container          If non-null, this is the parent view that the
+     *                           fragment's UI should be attached to.
+     * @param savedInstanceState If non-null, this fragment is being re-constructed
+     *                           from a previous saved state.
      * @return The root view for the fragment's UI.
      */
     @Nullable
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+            @Nullable Bundle savedInstanceState) {
         binding = FragmentEditProfileBinding.inflate(inflater, container, false);
         return binding.getRoot();
     }
 
     /**
-     * Initializes the ViewModels, NavController, and sets up UI observers and click listeners
+     * Initializes the ViewModels, NavController, and sets up UI observers and click
+     * listeners
      * after the view has been created.
-     * @param view The view returned by {@link #onCreateView(LayoutInflater, ViewGroup, Bundle)}.
-     * @param savedInstanceState If non-null, this fragment is being re-constructed from a previous saved state.
+     * 
+     * @param view               The view returned by
+     *                           {@link #onCreateView(LayoutInflater, ViewGroup, Bundle)}.
+     * @param savedInstanceState If non-null, this fragment is being re-constructed
+     *                           from a previous saved state.
      */
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
         viewModel = new ViewModelProvider(requireActivity()).get(ProfileViewModel.class);
-        viewModel.resetFlags();                           // Reset edit flags first thing
+        viewModel.resetFlags(); // Reset edit flags first thing
         authViewModel = new ViewModelProvider(requireActivity()).get(AuthViewModel.class);
         navController = Navigation.findNavController(view);
 
@@ -71,7 +80,8 @@ public class EditProfileFragment extends Fragment {
     }
 
     /**
-     * Sets up observers on LiveData from the ViewModels to update the UI in response to data changes,
+     * Sets up observers on LiveData from the ViewModels to update the UI in
+     * response to data changes,
      * such as user information, loading states, and success or error messages.
      */
     private void setupObservers() {
@@ -103,13 +113,14 @@ public class EditProfileFragment extends Fragment {
             if (success) {
                 Toast.makeText(getContext(), "Account deleted successfully.", Toast.LENGTH_SHORT).show();
                 authViewModel.logout();
-                viewModel.resetFlags();     //resetting after userless logout to prevent errors on login
+                viewModel.resetFlags(); // resetting after userless logout to prevent errors on login
             }
         });
     }
 
     /**
-     * Sets up click listeners for the interactive UI elements in the fragment, such as the
+     * Sets up click listeners for the interactive UI elements in the fragment, such
+     * as the
      * "Save Changes" and "Delete Account" buttons.
      */
     private void setupClickListeners() {
@@ -128,12 +139,63 @@ public class EditProfileFragment extends Fragment {
         String newPassword = binding.etNewPassword.getText().toString();
         String confirmPassword = binding.etConfirmPassword.getText().toString();
 
+        if (username.length() < 3) {
+            Toast.makeText(getContext(), "Username must be at least 3 characters long.", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        // Check if email is being updated but current password is not provided
+        com.appsters.unlimitedgames.app.data.model.User currentUser = viewModel.getCurrentUser().getValue();
+        if (currentUser != null && !email.equals(currentUser.getEmail()) && currentPassword.isEmpty()) {
+            showPasswordPromptForUpdate(username, email, newPassword, confirmPassword);
+            return;
+        }
+
         // ViewModel handles all validation and sequencing
         viewModel.updateProfile(username, email, currentPassword, newPassword, confirmPassword);
     }
 
     /**
-     * Displays an alert dialog to confirm whether the user wants to proceed with deleting their account.
+     * Displays a dialog prompting the user to enter their password to confirm
+     * profile updates (like email change).
+     */
+    private void showPasswordPromptForUpdate(String username, String email, String newPassword,
+            String confirmPassword) {
+        FrameLayout container = new FrameLayout(requireContext());
+        final com.google.android.material.textfield.TextInputEditText input = new com.google.android.material.textfield.TextInputEditText(
+                requireContext());
+        input.setInputType(
+                android.text.InputType.TYPE_CLASS_TEXT | android.text.InputType.TYPE_TEXT_VARIATION_PASSWORD);
+        input.setHint("Enter password");
+
+        FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT);
+        int margin = (int) (16 * getResources().getDisplayMetrics().density); // 16dp margin
+        params.setMargins(margin, 0, margin, 0);
+        input.setLayoutParams(params);
+
+        container.addView(input);
+
+        new MaterialAlertDialogBuilder(requireContext(), R.style.DeleteDialogueTheme)
+                .setTitle("Confirm Changes")
+                .setMessage("Please enter your current password to update your email.")
+                .setView(container)
+                .setNegativeButton("Cancel", null)
+                .setPositiveButton("Confirm", (dialog, which) -> {
+                    String password = input.getText().toString();
+                    if (!password.isEmpty()) {
+                        viewModel.updateProfile(username, email, password, newPassword, confirmPassword);
+                    } else {
+                        Toast.makeText(getContext(), "Password is required.", Toast.LENGTH_SHORT).show();
+                    }
+                })
+                .show();
+    }
+
+    /**
+     * Displays an alert dialog to confirm whether the user wants to proceed with
+     * deleting their account.
      * If confirmed, it proceeds to show the password prompt.
      */
     private void showDeleteConfirmationDialog() {
@@ -146,20 +208,24 @@ public class EditProfileFragment extends Fragment {
     }
 
     /**
-     * Displays a dialog prompting the user to enter their password to confirm account deletion.
-     * The input field is placed in a FrameLayout to add horizontal margins for better visual presentation.
+     * Displays a dialog prompting the user to enter their password to confirm
+     * account deletion.
+     * The input field is placed in a FrameLayout to add horizontal margins for
+     * better visual presentation.
      */
     private void showPasswordPromptForDelete() {
         FrameLayout container = new FrameLayout(requireContext());
-        final com.google.android.material.textfield.TextInputEditText input = new com.google.android.material.textfield.TextInputEditText(requireContext());
-        input.setInputType(android.text.InputType.TYPE_CLASS_TEXT | android.text.InputType.TYPE_TEXT_VARIATION_PASSWORD);
+        final com.google.android.material.textfield.TextInputEditText input = new com.google.android.material.textfield.TextInputEditText(
+                requireContext());
+        input.setInputType(
+                android.text.InputType.TYPE_CLASS_TEXT | android.text.InputType.TYPE_TEXT_VARIATION_PASSWORD);
         input.setHint("Enter your password");
 
-        //gemini added a frame layout to limit the size of the password entry text field
+        // gemini added a frame layout to limit the size of the password entry text
+        // field
         FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-        );
+                ViewGroup.LayoutParams.WRAP_CONTENT);
         int margin = (int) (16 * getResources().getDisplayMetrics().density); // 16dp margin
         params.setMargins(margin, 0, margin, 0);
         input.setLayoutParams(params);
@@ -182,7 +248,8 @@ public class EditProfileFragment extends Fragment {
     }
 
     /**
-     * Cleans up the binding when the fragment's view is destroyed to prevent memory leaks.
+     * Cleans up the binding when the fragment's view is destroyed to prevent memory
+     * leaks.
      */
     @Override
     public void onDestroyView() {

--- a/app/src/main/java/com/appsters/unlimitedgames/app/ui/profile/ProfileViewModel.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/app/ui/profile/ProfileViewModel.java
@@ -16,7 +16,8 @@ import com.appsters.unlimitedgames.app.util.Privacy;
 
 /**
  * ViewModel for the Profile screen.
- * Handles loading and updating user profile data, including privacy settings and profile picture.
+ * Handles loading and updating user profile data, including privacy settings
+ * and profile picture.
  * Also handles user logout.
  */
 public class ProfileViewModel extends ViewModel {
@@ -52,6 +53,7 @@ public class ProfileViewModel extends ViewModel {
 
     /**
      * Returns the LiveData for the current user.
+     * 
      * @return A LiveData object containing the current user's data.
      */
     public LiveData<User> getCurrentUser() {
@@ -60,6 +62,7 @@ public class ProfileViewModel extends ViewModel {
 
     /**
      * Returns the LiveData for the loading state.
+     * 
      * @return A LiveData object indicating if data is being loaded.
      */
     public LiveData<Boolean> getIsLoading() {
@@ -68,6 +71,7 @@ public class ProfileViewModel extends ViewModel {
 
     /**
      * Returns the LiveData for error messages.
+     * 
      * @return A LiveData object containing any error messages.
      */
     public LiveData<String> getErrorMessage() {
@@ -76,6 +80,7 @@ public class ProfileViewModel extends ViewModel {
 
     /**
      * Returns the LiveData for the logout completion status.
+     * 
      * @return A LiveData object that is true when logout is complete.
      */
     public LiveData<Boolean> getLogoutComplete() {
@@ -84,6 +89,7 @@ public class ProfileViewModel extends ViewModel {
 
     /**
      * Returns the LiveData for the image upload success status.
+     * 
      * @return A LiveData object that is true when image upload is successful.
      */
     public LiveData<Boolean> getImageUploadSuccess() {
@@ -92,6 +98,7 @@ public class ProfileViewModel extends ViewModel {
 
     /**
      * Returns the LiveData for the profile update success status.
+     * 
      * @return A LiveData object that is true when profile update is successful.
      */
     public LiveData<Boolean> getUpdateSuccess() {
@@ -100,6 +107,7 @@ public class ProfileViewModel extends ViewModel {
 
     /**
      * Returns the LiveData for the account deletion success status.
+     * 
      * @return A LiveData object that is true when account deletion is successful.
      */
     public LiveData<Boolean> getDeleteSuccess() {
@@ -116,7 +124,8 @@ public class ProfileViewModel extends ViewModel {
 
     /**
      * Loads the current user's profile from Firestore.
-     * It fetches the user data associated with the currently authenticated Firebase user.
+     * It fetches the user data associated with the currently authenticated Firebase
+     * user.
      */
     public void loadCurrentUser() {
         FirebaseUser firebaseUser = auth.getCurrentUser();
@@ -138,7 +147,8 @@ public class ProfileViewModel extends ViewModel {
 
     public void updatePrivacy(Privacy privacy) {
         User user = currentUser.getValue();
-        if (user == null) return;
+        if (user == null)
+            return;
 
         user.setPrivacy(privacy);
         updateUser(user);
@@ -146,7 +156,8 @@ public class ProfileViewModel extends ViewModel {
 
     public void updateProfilePicture(String base64Image) {
         User user = currentUser.getValue();
-        if (user == null) return;
+        if (user == null)
+            return;
 
         user.setProfileImageUrl(base64Image);
         imageUploadSuccess.setValue(false); // Reset before upload
@@ -158,7 +169,7 @@ public class ProfileViewModel extends ViewModel {
      * Ensures proper sequencing and only one success callback.
      */
     public void updateProfile(String newUsername, String newEmail, String currentPassword,
-                              String newPassword, String confirmPassword) {
+            String newPassword, String confirmPassword) {
         User user = currentUser.getValue();
         if (user == null) {
             errorMessage.setValue("User data not loaded");
@@ -167,8 +178,7 @@ public class ProfileViewModel extends ViewModel {
 
         // Validate all inputs first
         ValidationResult validation = validateProfileUpdate(
-                user, newUsername, newEmail, currentPassword, newPassword, confirmPassword
-        );
+                user, newUsername, newEmail, currentPassword, newPassword, confirmPassword);
 
         if (!validation.isValid) {
             errorMessage.setValue(validation.errorMessage);
@@ -183,12 +193,12 @@ public class ProfileViewModel extends ViewModel {
         // Execute updates in proper sequence
         if (emailChanged || passwordChanged) {
             // Need reauthentication for email/password changes
-            updateWithReauth(user, newUsername, newEmail, currentPassword,
+            updateWithReauth(user, newEmail, newUsername, currentPassword,
                     newPassword, usernameChanged, emailChanged, passwordChanged);
         } else if (usernameChanged) {
             // Just username - no reauth needed
             updateUsername(newUsername);
-        }else {
+        } else {
             errorMessage.setValue("No changes detected");
         }
     }
@@ -197,8 +207,8 @@ public class ProfileViewModel extends ViewModel {
      * Validates all profile update inputs.
      */
     private ValidationResult validateProfileUpdate(User user, String newUsername, String newEmail,
-                                                   String currentPassword, String newPassword,
-                                                   String confirmPassword) {
+            String currentPassword, String newPassword,
+            String confirmPassword) {
         // Email validation
         if (TextUtils.isEmpty(newEmail) && !android.util.Patterns.EMAIL_ADDRESS.matcher(newEmail).matches()) {
             return new ValidationResult(false, "Invalid email address");
@@ -249,9 +259,9 @@ public class ProfileViewModel extends ViewModel {
      * Executes in proper sequence: reauth → email → password → username/firestore
      */
     private void updateWithReauth(User user, String newEmail, String newUsername,
-                                  String currentPassword, String newPassword,
-                                  boolean usernameChanged, boolean emailChanged,
-                                  boolean passwordChanged) {
+            String currentPassword, String newPassword,
+            boolean usernameChanged, boolean emailChanged,
+            boolean passwordChanged) {
         reauthenticate(user.getEmail(), currentPassword, () -> {
             FirebaseUser firebaseUser = auth.getCurrentUser();
             if (firebaseUser == null) {
@@ -276,8 +286,8 @@ public class ProfileViewModel extends ViewModel {
      * Updates email in Firebase Auth, then continues with other updates.
      */
     private void updateEmailThenContinue(FirebaseUser firebaseUser, User user, String newEmail,
-                                         String newPassword, String newUsername,
-                                         boolean passwordChanged, boolean usernameChanged) {
+            String newPassword, String newUsername,
+            boolean passwordChanged, boolean usernameChanged) {
         firebaseUser.verifyBeforeUpdateEmail(newEmail).addOnCompleteListener(task -> {
             if (task.isSuccessful()) {
                 user.setEmail(newEmail);
@@ -299,8 +309,8 @@ public class ProfileViewModel extends ViewModel {
      * Updates password in Firebase Auth, then continues with other updates.
      */
     private void updatePasswordThenContinue(FirebaseUser firebaseUser, User user,
-                                            String newUsername, String newPassword,
-                                            boolean usernameChanged) {
+            String newUsername, String newPassword,
+            boolean usernameChanged) {
         firebaseUser.updatePassword(newPassword).addOnCompleteListener(task -> {
             if (task.isSuccessful()) {
                 finalizeProfileUpdate(user, newUsername, usernameChanged);
@@ -323,7 +333,8 @@ public class ProfileViewModel extends ViewModel {
 
     public void updateUsername(String newUsername) {
         User user = currentUser.getValue();
-        if (user == null) return;
+        if (user == null)
+            return;
 
         user.setUsername(newUsername);
         updateUser(user);
@@ -332,10 +343,11 @@ public class ProfileViewModel extends ViewModel {
     public void updateUserEmail(String newEmail, String password) {
         FirebaseUser firebaseUser = auth.getCurrentUser();
         User user = currentUser.getValue();
-        if (firebaseUser == null || user == null) return;
+        if (firebaseUser == null || user == null)
+            return;
         isLoading.setValue(true);
         reauthenticate(user.getEmail(), password, () -> {
-                firebaseUser.verifyBeforeUpdateEmail(newEmail).addOnCompleteListener(task -> {
+            firebaseUser.verifyBeforeUpdateEmail(newEmail).addOnCompleteListener(task -> {
                 if (task.isSuccessful()) {
                     user.setEmail(newEmail);
                     updateUser(user);
@@ -350,7 +362,8 @@ public class ProfileViewModel extends ViewModel {
     public void updatePassword(String currentPassword, String newPassword) {
         FirebaseUser firebaseUser = auth.getCurrentUser();
         User user = currentUser.getValue();
-        if (firebaseUser == null || user == null) return;
+        if (firebaseUser == null || user == null)
+            return;
 
         reauthenticate(user.getEmail(), currentPassword, () -> {
             isLoading.setValue(true);
@@ -368,7 +381,8 @@ public class ProfileViewModel extends ViewModel {
     public void deleteAccount(String password) {
         FirebaseUser firebaseUser = auth.getCurrentUser();
         User user = currentUser.getValue();
-        if (firebaseUser == null || user == null) return;
+        if (firebaseUser == null || user == null)
+            return;
 
         reauthenticate(user.getEmail(), password, () -> {
             isLoading.setValue(true);
@@ -380,7 +394,8 @@ public class ProfileViewModel extends ViewModel {
                             currentUser.setValue(null);
                             deleteSuccess.setValue(true);
                         } else {
-                            errorMessage.setValue("Failed to delete Firebase Auth user: " + deleteTask.getException().getMessage());
+                            errorMessage.setValue(
+                                    "Failed to delete Firebase Auth user: " + deleteTask.getException().getMessage());
                         }
                     });
                 } else {
@@ -410,7 +425,8 @@ public class ProfileViewModel extends ViewModel {
 
     private void reauthenticate(String email, String password, Runnable onReAuthSuccess) {
         FirebaseUser user = auth.getCurrentUser();
-        if (user == null) return;
+        if (user == null)
+            return;
 
         AuthCredential credential = EmailAuthProvider.getCredential(email, password);
         isLoading.setValue(true);
@@ -425,8 +441,9 @@ public class ProfileViewModel extends ViewModel {
     }
 
     public void logout() {
-        // This was actually handled in the profile fragment and is loads easier to do there using AuthViewModel
-        //auth.signOut();
+        // This was actually handled in the profile fragment and is loads easier to do
+        // there using AuthViewModel
+        // auth.signOut();
         currentUser.setValue(null);
         logoutComplete.setValue(true);
     }

--- a/app/src/main/java/com/appsters/unlimitedgames/games/maze/controller/RunManager.kt
+++ b/app/src/main/java/com/appsters/unlimitedgames/games/maze/controller/RunManager.kt
@@ -172,6 +172,19 @@ object RunManager {
         }
     }
 
+    fun clearAllData(context: Context) {
+        clearSavedGame(context)
+        // Reset static state
+        totalMoney = 0
+        totalXP = 0
+        currentLevel = 1
+        roundNumber = 1
+        isRunInProgress = false
+        currentLevelXP = 0
+        xpToNextLevel = GameConfig.XP_PER_LEVEL_BASE
+        player.reset()
+    }
+
     private fun checkLevelUp(): Boolean {
         if (currentLevelXP >= xpToNextLevel) {
             currentLevelXP -= xpToNextLevel

--- a/app/src/main/java/com/appsters/unlimitedgames/games/sudoku/repository/SudokuRepository.kt
+++ b/app/src/main/java/com/appsters/unlimitedgames/games/sudoku/repository/SudokuRepository.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Color
 import com.appsters.unlimitedgames.games.sudoku.SudokuMenuFragment
 import com.appsters.unlimitedgames.games.sudoku.model.Score
+import androidx.core.content.edit
 
 /**
  * A repository for handling Sudoku game data, such as high scores and user preferences.
@@ -28,7 +29,7 @@ class SudokuRepository(context: Context) {
         val currentHighScore = prefs.getInt(key, 0)
 
         if (newScoreValue > currentHighScore) {
-            prefs.edit().putInt(key, newScoreValue).apply()
+            prefs.edit { putInt(key, newScoreValue) }
         }
     }
 
@@ -44,7 +45,7 @@ class SudokuRepository(context: Context) {
      * Saves the last color selected by the player.
      */
     fun saveLastColor(color: Int) {
-        prefs.edit().putInt(LAST_COLOR_KEY, color).apply()
+        prefs.edit { putInt(LAST_COLOR_KEY, color) }
     }
 
     /**
@@ -61,12 +62,12 @@ class SudokuRepository(context: Context) {
     fun saveGameState(gameState: com.appsters.unlimitedgames.games.sudoku.model.GameState, difficulty: SudokuMenuFragment.Difficulty) {
         val json = com.google.gson.Gson().toJson(gameState)
         val key = SAVED_GAME_STATE_KEY + "_" + difficulty.name
-        prefs.edit().putString(key, json).apply()
+        prefs.edit { putString(key, json) }
     }
 
     /**
      * Retrieves the saved game state from SharedPreferences.
-     * @return The saved [GameState], or null if no game is saved.
+     * @return The saved [com.appsters.unlimitedgames.games.sudoku.model.GameState], or null if no game is saved.
      */
     fun getSavedGameState(difficulty: SudokuMenuFragment.Difficulty): com.appsters.unlimitedgames.games.sudoku.model.GameState? {
         val key = SAVED_GAME_STATE_KEY + "_" + difficulty.name
@@ -91,6 +92,13 @@ class SudokuRepository(context: Context) {
      */
     fun clearSavedGame(difficulty: SudokuMenuFragment.Difficulty) {
         val key = SAVED_GAME_STATE_KEY + "_" + difficulty.name
-        prefs.edit().remove(key).apply()
+        prefs.edit { remove(key) }
+    }
+
+    /**
+     * Clears all Sudoku data including high scores and saved games.
+     */
+    fun clearAllData() {
+        prefs.edit { clear() }
     }
 }

--- a/app/src/main/java/com/appsters/unlimitedgames/games/whackamole/repository/GameRepository.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/games/whackamole/repository/GameRepository.java
@@ -24,4 +24,9 @@ public interface GameRepository {
      * @param score the new high score to save
      */
     void saveHighScore(int score);
+
+    /**
+     * Clears all game data.
+     */
+    void clearData();
 }

--- a/app/src/main/java/com/appsters/unlimitedgames/games/whackamole/repository/SharedPrefGameRepository.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/games/whackamole/repository/SharedPrefGameRepository.java
@@ -50,4 +50,10 @@ public class SharedPrefGameRepository implements GameRepository {
                 .apply();
         highScore.setValue(score);
     }
+
+    @Override
+    public void clearData() {
+        prefs.edit().remove(KEY_HIGH_SCORE).apply();
+        highScore.setValue(0);
+    }
 }


### PR DESCRIPTION
Closes #29, closes #30, closes #19

This PR addresses UI/UX bugs in the profile and navigation modules and enforces security/privacy best practices upon logout.

Changelog:
- Profile Validation: Added input validation to the "Edit Profile" screen to catch username updates that are shorter than the minimum length requirement.
- Account Security UX: implemented a logic check for email updates. If a user attempts to update their email address without providing a password (and isn't using the Change Password field), an AlertDialogue now prompts them to provide their current password.
- Navigation Fix: Fixed a state issue where the Navbar would persist on the "Profile" tab after logging out and signing back in. It now correctly defaults to highlighting the "Home" page on a fresh login. Clears stacks
- Data Cleanup: Implemented a clearData() in GameDataSource, triggered on logout. This clears local high score caches (Sudoku, Maze, Whackamole) and prevents data leakage between users on the same device. 