### PR TITLE
feat: Implement user data cleanup on logout

### DIFF
--- a/app/src/main/java/com/appsters/unlimitedgames/app/MainActivity.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/app/MainActivity.java
@@ -17,6 +17,7 @@ import androidx.navigation.ui.NavigationUI;
 import com.appsters.unlimitedgames.R;
 import com.appsters.unlimitedgames.databinding.ActivityMainBinding;
 import com.appsters.unlimitedgames.app.ui.auth.AuthViewModel;
+import com.appsters.unlimitedgames.app.ui.auth.AuthViewModelFactory;
 import com.appsters.unlimitedgames.app.ui.auth.AuthState;
 
 /**
@@ -58,7 +59,8 @@ public class MainActivity extends AppCompatActivity {
 
         setSupportActionBar(binding.toolbar);
 
-        authViewModel = new ViewModelProvider(this).get(AuthViewModel.class);
+        AuthViewModelFactory factory = new AuthViewModelFactory(getApplication());
+        authViewModel = new ViewModelProvider(this, factory).get(AuthViewModel.class);
 
         NavHostFragment navHostFragment = (NavHostFragment) getSupportFragmentManager()
                 .findFragmentById(R.id.nav_host_fragment);
@@ -131,9 +133,6 @@ public class MainActivity extends AppCompatActivity {
                 binding.bottomNav.setVisibility(View.GONE);
                 if (getSupportActionBar() != null)
                     getSupportActionBar().hide();
-
-                // Clear all game data on logout
-                com.appsters.unlimitedgames.app.data.GameDataSource.clearAllGameData(this);
                 break;
 
             case ERROR:

--- a/app/src/main/java/com/appsters/unlimitedgames/app/managers/GameCleanupManager.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/app/managers/GameCleanupManager.java
@@ -1,0 +1,20 @@
+package com.appsters.unlimitedgames.app.managers;
+
+import com.appsters.unlimitedgames.games.interfaces.IGame;
+import java.util.List;
+
+public class GameCleanupManager {
+    private final List<IGame> games;
+
+    public GameCleanupManager(List<IGame> games) {
+        this.games = games;
+    }
+
+    public void clearAllGameData() {
+        if (games != null) {
+            for (IGame game : games) {
+                game.clearUserData();
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/appsters/unlimitedgames/app/ui/auth/AuthViewModel.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/app/ui/auth/AuthViewModel.java
@@ -11,24 +11,28 @@ import com.google.firebase.auth.FirebaseUser;
 
 /**
  * ViewModel for authentication-related operations.
- * This ViewModel handles user sign-up, sign-in, and sign-out, and exposes the current
+ * This ViewModel handles user sign-up, sign-in, and sign-out, and exposes the
+ * current
  * authentication state to the UI.
  */
 public class AuthViewModel extends ViewModel {
 
     private final FirebaseAuth firebaseAuth;
     private final UserRepository userRepository;
+    private final com.appsters.unlimitedgames.app.managers.GameCleanupManager gameCleanupManager;
     private final MutableLiveData<AuthState> authState = new MutableLiveData<>();
     private final MutableLiveData<FirebaseUser> user = new MutableLiveData<>();
     private String errorMessage;
 
     /**
      * Constructs a new AuthViewModel and initializes Firebase Auth.
-     * It also checks the current authentication state to see if a user is already signed in.
+     * It also checks the current authentication state to see if a user is already
+     * signed in.
      */
-    public AuthViewModel() {
-        firebaseAuth = FirebaseAuth.getInstance();
-        userRepository = new UserRepository();
+    public AuthViewModel(com.appsters.unlimitedgames.app.managers.GameCleanupManager gameCleanupManager) {
+        this.firebaseAuth = FirebaseAuth.getInstance();
+        this.userRepository = new UserRepository();
+        this.gameCleanupManager = gameCleanupManager;
 
         // Check if a user is already logged in
         FirebaseUser currentUser = firebaseAuth.getCurrentUser();
@@ -52,7 +56,8 @@ public class AuthViewModel extends ViewModel {
     /**
      * Gets the currently authenticated user.
      *
-     * @return A LiveData object that emits the current {@link FirebaseUser}, or null if no user is
+     * @return A LiveData object that emits the current {@link FirebaseUser}, or
+     *         null if no user is
      *         authenticated.
      */
     public LiveData<FirebaseUser> getUser() {
@@ -71,8 +76,10 @@ public class AuthViewModel extends ViewModel {
     /**
      * Signs up a new user with the given email and password.
      * Creates both a Firebase Auth account and a Firestore user profile.
-     * The authentication state will be updated to {@link AuthState#LOADING} during the operation,
-     * and then to {@link AuthState#AUTHENTICATED} on success or {@link AuthState#ERROR} on failure.
+     * The authentication state will be updated to {@link AuthState#LOADING} during
+     * the operation,
+     * and then to {@link AuthState#AUTHENTICATED} on success or
+     * {@link AuthState#ERROR} on failure.
      *
      * @param email    The user's email address.
      * @param password The user's password.
@@ -90,8 +97,8 @@ public class AuthViewModel extends ViewModel {
                             authState.setValue(AuthState.ERROR);
                         }
                     } else {
-                        errorMessage = task.getException() != null ?
-                                task.getException().getMessage() : "Sign up failed";
+                        errorMessage = task.getException() != null ? task.getException().getMessage()
+                                : "Sign up failed";
                         authState.setValue(AuthState.ERROR);
                     }
                 });
@@ -121,8 +128,10 @@ public class AuthViewModel extends ViewModel {
 
     /**
      * Signs in an existing user with the given email and password.
-     * The authentication state will be updated to {@link AuthState#LOADING} during the operation,
-     * and then to {@link AuthState#AUTHENTICATED} on success or {@link AuthState#ERROR} on failure.
+     * The authentication state will be updated to {@link AuthState#LOADING} during
+     * the operation,
+     * and then to {@link AuthState#AUTHENTICATED} on success or
+     * {@link AuthState#ERROR} on failure.
      *
      * @param email    The user's email address.
      * @param password The user's password.
@@ -135,8 +144,8 @@ public class AuthViewModel extends ViewModel {
                         user.setValue(firebaseAuth.getCurrentUser());
                         authState.setValue(AuthState.AUTHENTICATED);
                     } else {
-                        errorMessage = task.getException() != null ?
-                                task.getException().getMessage() : "Sign in failed";
+                        errorMessage = task.getException() != null ? task.getException().getMessage()
+                                : "Sign in failed";
                         authState.setValue(AuthState.ERROR);
                     }
                 });
@@ -144,9 +153,11 @@ public class AuthViewModel extends ViewModel {
 
     /**
      * Signs out the currently authenticated user.
-     * The authentication state will be updated to {@link AuthState#UNAUTHENTICATED}.
+     * The authentication state will be updated to
+     * {@link AuthState#UNAUTHENTICATED}.
      */
     public void logout() {
+        gameCleanupManager.clearAllGameData();
         firebaseAuth.signOut();
         authState.setValue(AuthState.UNAUTHENTICATED);
     }

--- a/app/src/main/java/com/appsters/unlimitedgames/app/ui/auth/AuthViewModelFactory.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/app/ui/auth/AuthViewModelFactory.java
@@ -1,0 +1,41 @@
+package com.appsters.unlimitedgames.app.ui.auth;
+
+import android.app.Application;
+import androidx.annotation.NonNull;
+import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
+import com.appsters.unlimitedgames.app.managers.GameCleanupManager;
+import com.appsters.unlimitedgames.games.interfaces.IGame;
+import com.appsters.unlimitedgames.games.game2048.Game2048Game;
+import com.appsters.unlimitedgames.games.whackamole.WhackAMoleGame;
+import com.appsters.unlimitedgames.games.sudoku.SudokuGame;
+import com.appsters.unlimitedgames.games.maze.MazeGame;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AuthViewModelFactory implements ViewModelProvider.Factory {
+    private final Application application;
+
+    public AuthViewModelFactory(Application application) {
+        this.application = application;
+    }
+
+    @NonNull
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
+        if (modelClass.isAssignableFrom(AuthViewModel.class)) {
+            List<IGame> games = new ArrayList<>();
+            // Initialize game adapters (passing Application context)
+            games.add(new Game2048Game(application));
+            games.add(new WhackAMoleGame(application));
+            games.add(new SudokuGame(application));
+            games.add(new MazeGame(application));
+
+            GameCleanupManager manager = new GameCleanupManager(games);
+            return (T) new AuthViewModel(manager);
+        }
+        throw new IllegalArgumentException("Unknown ViewModel class");
+    }
+}

--- a/app/src/main/java/com/appsters/unlimitedgames/app/ui/auth/LoginFragment.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/app/ui/auth/LoginFragment.java
@@ -16,6 +16,7 @@ import androidx.navigation.Navigation;
 
 import com.appsters.unlimitedgames.R;
 import com.appsters.unlimitedgames.databinding.FragmentLoginBinding;
+import com.appsters.unlimitedgames.app.ui.auth.AuthViewModelFactory;
 
 /**
  * A simple {@link Fragment} subclass that handles user login.
@@ -34,29 +35,37 @@ public class LoginFragment extends Fragment {
     /**
      * Called when the fragment is created.
      * It initializes the {@link AuthViewModel}.
+     * 
      * @param savedInstanceState If the fragment is being re-created from
-     * a previous saved state, this is the state.
+     *                           a previous saved state, this is the state.
      */
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        viewModel = new ViewModelProvider(requireActivity()).get(AuthViewModel.class);
+        AuthViewModelFactory factory = new AuthViewModelFactory(requireActivity().getApplication());
+        viewModel = new ViewModelProvider(requireActivity(), factory).get(AuthViewModel.class);
     }
 
     /**
      * Inflates the layout for this fragment.
-     * @param inflater The LayoutInflater object that can be used to inflate
-     * any views in the fragment,
-     * @param container If non-null, this is the parent view that the fragment's
-     * UI should be attached to.  The fragment should not add the view itself,
-     * but this can be used to generate the LayoutParams of the view.
+     * 
+     * @param inflater           The LayoutInflater object that can be used to
+     *                           inflate
+     *                           any views in the fragment,
+     * @param container          If non-null, this is the parent view that the
+     *                           fragment's
+     *                           UI should be attached to. The fragment should not
+     *                           add the view itself,
+     *                           but this can be used to generate the LayoutParams
+     *                           of the view.
      * @param savedInstanceState If non-null, this fragment is being re-constructed
-     * from a previous saved state as given here.
+     *                           from a previous saved state as given here.
      * @return The root view of the fragment.
      */
     @Nullable
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+            @Nullable Bundle savedInstanceState) {
         binding = FragmentLoginBinding.inflate(inflater, container, false);
         return binding.getRoot();
     }
@@ -64,9 +73,10 @@ public class LoginFragment extends Fragment {
     /**
      * Called when the fragment's view has been created.
      * It sets up the click listeners and observers for the fragment.
-     * @param view The created view.
+     * 
+     * @param view               The created view.
      * @param savedInstanceState If non-null, this fragment is being re-constructed
-     * from a previous saved state as given here.
+     *                           from a previous saved state as given here.
      */
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {

--- a/app/src/main/java/com/appsters/unlimitedgames/app/ui/auth/SignUpFragment.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/app/ui/auth/SignUpFragment.java
@@ -16,10 +16,12 @@ import androidx.navigation.Navigation;
 
 import com.appsters.unlimitedgames.R;
 import com.appsters.unlimitedgames.databinding.FragmentSignupBinding;
+import com.appsters.unlimitedgames.app.ui.auth.AuthViewModelFactory;
 
 /**
  * A simple {@link Fragment} subclass that handles user registration.
- * It allows new users to create an account by providing a username, email, and password.
+ * It allows new users to create an account by providing a username, email, and
+ * password.
  */
 public class SignUpFragment extends Fragment {
 
@@ -33,29 +35,37 @@ public class SignUpFragment extends Fragment {
     /**
      * Called when the fragment is created.
      * It initializes the {@link AuthViewModel}.
+     * 
      * @param savedInstanceState If the fragment is being re-created from
-     * a previous saved state, this is the state.
+     *                           a previous saved state, this is the state.
      */
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        viewModel = new ViewModelProvider(requireActivity()).get(AuthViewModel.class);
+        AuthViewModelFactory factory = new AuthViewModelFactory(requireActivity().getApplication());
+        viewModel = new ViewModelProvider(requireActivity(), factory).get(AuthViewModel.class);
     }
 
     /**
      * Inflates the layout for this fragment.
-     * @param inflater The LayoutInflater object that can be used to inflate
-     * any views in the fragment,
-     * @param container If non-null, this is the parent view that the fragment's
-     * UI should be attached to. The fragment should not add the view itself,
-     * but this can be used to generate the LayoutParams of the view.
+     * 
+     * @param inflater           The LayoutInflater object that can be used to
+     *                           inflate
+     *                           any views in the fragment,
+     * @param container          If non-null, this is the parent view that the
+     *                           fragment's
+     *                           UI should be attached to. The fragment should not
+     *                           add the view itself,
+     *                           but this can be used to generate the LayoutParams
+     *                           of the view.
      * @param savedInstanceState If non-null, this fragment is being re-constructed
-     * from a previous saved state as given here.
+     *                           from a previous saved state as given here.
      * @return The root view of the fragment.
      */
     @Nullable
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+            @Nullable Bundle savedInstanceState) {
         binding = FragmentSignupBinding.inflate(inflater, container, false);
         return binding.getRoot();
     }
@@ -63,9 +73,10 @@ public class SignUpFragment extends Fragment {
     /**
      * Called when the fragment's view has been created.
      * It sets up the click listeners and observers for the fragment.
-     * @param view The created view.
+     * 
+     * @param view               The created view.
      * @param savedInstanceState If non-null, this fragment is being re-constructed
-     * from a previous saved state as given here.
+     *                           from a previous saved state as given here.
      */
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {

--- a/app/src/main/java/com/appsters/unlimitedgames/app/ui/friends/FindFriendsFragment.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/app/ui/friends/FindFriendsFragment.java
@@ -40,8 +40,7 @@ public class FindFriendsFragment extends Fragment {
     public View onCreateView(
             @NonNull LayoutInflater inflater,
             @Nullable ViewGroup container,
-            @Nullable Bundle savedInstanceState
-    ) {
+            @Nullable Bundle savedInstanceState) {
         binding = FragmentFindFriendsBinding.inflate(inflater, container, false);
         return binding.getRoot();
     }
@@ -49,8 +48,7 @@ public class FindFriendsFragment extends Fragment {
     @Override
     public void onViewCreated(
             @NonNull View view,
-            @Nullable Bundle savedInstanceState
-    ) {
+            @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
         viewModel = new ViewModelProvider(requireActivity()).get(FriendViewModel.class);
@@ -113,8 +111,7 @@ public class FindFriendsFragment extends Fragment {
                     me.getUserId(),
                     user.getUserId(),
                     me.getUsername(),
-                    user.getUsername()
-            );
+                    user.getUsername());
         });
 
         binding.rvSearchResults.setLayoutManager(new LinearLayoutManager(requireContext()));
@@ -155,8 +152,13 @@ public class FindFriendsFragment extends Fragment {
 
         binding.etSearchFriends.addTextChangedListener(new TextWatcher() {
 
-            @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
-            @Override public void afterTextChanged(Editable s) {}
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+            }
 
             @Override
             public void onTextChanged(CharSequence s, int start, int before, int count) {
@@ -172,28 +174,8 @@ public class FindFriendsFragment extends Fragment {
     }
 
     private void applyFilter(String query) {
-
-        String q = query.trim().toLowerCase();
-
-        List<User> currentList = viewModel.getNewFriends().getValue();
-        if (currentList == null) return;
-
-        if (q.isEmpty()) {
-            adapter.submitList(currentList);
-            binding.emptyText.setVisibility(View.GONE);
-            return;
-        }
-
-        List<User> filtered = new ArrayList<>();
-        for (User u : currentList) {
-            if (u.getUsername() != null &&
-                    u.getUsername().toLowerCase().contains(q)) {
-                filtered.add(u);
-            }
-        }
-
-        adapter.submitList(filtered);
-        binding.emptyText.setVisibility(filtered.isEmpty() ? View.VISIBLE : View.GONE);
+        // Delegate search to ViewModel for server-side privacy filtering
+        viewModel.searchNewFriends(query);
     }
 
     @Override

--- a/app/src/main/java/com/appsters/unlimitedgames/app/ui/friends/FriendViewModel.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/app/ui/friends/FriendViewModel.java
@@ -36,18 +36,38 @@ public class FriendViewModel extends ViewModel {
 
     // ----------- LIVE DATA GETTERS -----------
 
-    public LiveData<Boolean> getIsLoading() { return isLoading; }
-    public LiveData<String> getErrorMessage() { return errorMessage; }
+    public LiveData<Boolean> getIsLoading() {
+        return isLoading;
+    }
 
-    public LiveData<List<Friend>> getFriends() { return friends; }
-    public LiveData<List<Friend>> getIncomingRequests() { return incomingRequests; }
-    public LiveData<List<Friend>> getOutgoingRequests() { return outgoingRequests; }
-    public LiveData<List<User>> getNewFriends() { return newFriends; }
+    public LiveData<String> getErrorMessage() {
+        return errorMessage;
+    }
+
+    public LiveData<List<Friend>> getFriends() {
+        return friends;
+    }
+
+    public LiveData<List<Friend>> getIncomingRequests() {
+        return incomingRequests;
+    }
+
+    public LiveData<List<Friend>> getOutgoingRequests() {
+        return outgoingRequests;
+    }
+
+    public LiveData<List<User>> getNewFriends() {
+        return newFriends;
+    }
 
     // ✅ CURRENT USER GETTER
-    public LiveData<User> getCurrentUser() { return currentUser; }
+    public LiveData<User> getCurrentUser() {
+        return currentUser;
+    }
 
-    public LiveData<Boolean> getActionSuccess() { return actionSuccess; }
+    public LiveData<Boolean> getActionSuccess() {
+        return actionSuccess;
+    }
 
     public void resetFlags() {
         actionSuccess.setValue(false);
@@ -124,8 +144,7 @@ public class FriendViewModel extends ViewModel {
             String fromUserId,
             String toUserId,
             String fromUsername,
-            String toUsername
-    ) {
+            String toUsername) {
         isLoading.setValue(true);
 
         friendRepository.sendFriendRequest(
@@ -141,8 +160,7 @@ public class FriendViewModel extends ViewModel {
                     } else {
                         errorMessage.setValue("Failed to send friend request.");
                     }
-                }
-        );
+                });
     }
 
     // ----------- ACCEPT FRIEND REQUEST -----------
@@ -208,4 +226,28 @@ public class FriendViewModel extends ViewModel {
             }
         });
     }
+
+    public void searchNewFriends(String query) {
+        User me = currentUser.getValue();
+        if (me == null) {
+            errorMessage.setValue("Current user not loaded.");
+            return;
+        }
+
+        if (query == null || query.trim().isEmpty()) {
+            loadAllNewFriends(me.getUserId());
+            return;
+        }
+
+        isLoading.setValue(true);
+        friendRepository.searchNewFriends(me.getUserId(), query, task -> {
+            isLoading.setValue(false);
+            if (task.isSuccessful()) {
+                newFriends.setValue(task.getResult());
+            } else {
+                errorMessage.setValue("Search failed.");
+            }
+        });
+    }
+
 }

--- a/app/src/main/java/com/appsters/unlimitedgames/app/ui/profile/ProfileFragment.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/app/ui/profile/ProfileFragment.java
@@ -29,6 +29,7 @@ import com.appsters.unlimitedgames.R;
 import com.appsters.unlimitedgames.app.data.model.User;
 import com.appsters.unlimitedgames.databinding.FragmentProfileBinding;
 import com.appsters.unlimitedgames.app.ui.auth.AuthViewModel;
+import com.appsters.unlimitedgames.app.ui.auth.AuthViewModelFactory;
 import com.appsters.unlimitedgames.app.util.ImageHelper;
 import com.appsters.unlimitedgames.app.util.Privacy;
 
@@ -51,8 +52,8 @@ public class ProfileFragment extends Fragment {
                 }
             });
 
-    private final ActivityResultLauncher<Intent> imagePickerLauncher =
-            registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
+    private final ActivityResultLauncher<Intent> imagePickerLauncher = registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(), result -> {
                 if (result.getResultCode() == Activity.RESULT_OK && result.getData() != null) {
                     Uri imageUri = result.getData().getData();
                     if (imageUri != null) {
@@ -63,7 +64,7 @@ public class ProfileFragment extends Fragment {
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
-                             @Nullable Bundle savedInstanceState) {
+            @Nullable Bundle savedInstanceState) {
         binding = FragmentProfileBinding.inflate(inflater, container, false);
         return binding.getRoot();
     }
@@ -74,7 +75,8 @@ public class ProfileFragment extends Fragment {
 
         viewModel = new ViewModelProvider(requireActivity()).get(ProfileViewModel.class);
         viewModel.resetFlags();
-        authViewModel = new ViewModelProvider(requireActivity()).get(AuthViewModel.class);
+        AuthViewModelFactory factory = new AuthViewModelFactory(requireActivity().getApplication());
+        authViewModel = new ViewModelProvider(requireActivity(), factory).get(AuthViewModel.class);
         navController = Navigation.findNavController(view);
         binding.setViewModel(viewModel);
         binding.setLifecycleOwner(getViewLifecycleOwner());
@@ -90,8 +92,7 @@ public class ProfileFragment extends Fragment {
         ArrayAdapter<Privacy> adapter = new ArrayAdapter<>(
                 requireContext(),
                 android.R.layout.simple_spinner_item,
-                Privacy.values()
-        );
+                Privacy.values());
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         binding.spinnerPrivacy.setAdapter(adapter);
 
@@ -235,8 +236,7 @@ public class ProfileFragment extends Fragment {
 
         int size = (int) (120 * getResources().getDisplayMetrics().density);
         binding.profileImage.setImageBitmap(
-                ImageHelper.createInitialsAvatar(initials, color, size)
-        );
+                ImageHelper.createInitialsAvatar(initials, color, size));
     }
 
     @Override

--- a/app/src/main/java/com/appsters/unlimitedgames/games/game2048/Game2048Game.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/games/game2048/Game2048Game.java
@@ -1,0 +1,24 @@
+package com.appsters.unlimitedgames.games.game2048;
+
+import android.content.Context;
+import com.appsters.unlimitedgames.games.interfaces.IGame;
+import com.appsters.unlimitedgames.games.game2048.repository.Cam2048Repository;
+
+public class Game2048Game implements IGame {
+    private final Context context;
+
+    public Game2048Game(Context context) {
+        this.context = context;
+    }
+
+    @Override
+    public void clearUserData() {
+        // Instantiate repository and clear state
+        // Note: Repository needs Application context usually, but if it takes Context
+        // it works.
+        // Assuming Cam2048Repository takes Context or Application.
+        Cam2048Repository repository = new Cam2048Repository(context);
+        repository.clearSavedState();
+        repository.clearHighScore();
+    }
+}

--- a/app/src/main/java/com/appsters/unlimitedgames/games/game2048/repository/Cam2048Repository.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/games/game2048/repository/Cam2048Repository.java
@@ -14,30 +14,38 @@ public class Cam2048Repository {
     private static final String SAVED_SCORE_KEY_PREFIX = "saved_score_";
 
     private final SharedPreferences sharedPreferences;
-    private final FirebaseUser currentUser;
 
     public Cam2048Repository(Context context) {
         sharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
-        currentUser = FirebaseAuth.getInstance().getCurrentUser();
+    }
+
+    private FirebaseUser getCurrentUser() {
+        return FirebaseAuth.getInstance().getCurrentUser();
     }
 
     public int getHighScore() {
-        if (currentUser == null) return 0;
-        return sharedPreferences.getInt(HIGH_SCORE_KEY_PREFIX + currentUser.getUid(), 0);
+        FirebaseUser user = getCurrentUser();
+        if (user == null)
+            return 0;
+        return sharedPreferences.getInt(HIGH_SCORE_KEY_PREFIX + user.getUid(), 0);
     }
 
     public void saveHighScore(int score) {
-        if (currentUser == null) return;
+        FirebaseUser user = getCurrentUser();
+        if (user == null)
+            return;
         int currentHighScore = getHighScore();
         if (score > currentHighScore) {
             SharedPreferences.Editor editor = sharedPreferences.edit();
-            editor.putInt(HIGH_SCORE_KEY_PREFIX + currentUser.getUid(), score);
+            editor.putInt(HIGH_SCORE_KEY_PREFIX + user.getUid(), score);
             editor.apply();
         }
     }
 
     public void saveGameState(int[][] board, int score) {
-        if (currentUser == null) return;
+        FirebaseUser user = getCurrentUser();
+        if (user == null)
+            return;
         SharedPreferences.Editor editor = sharedPreferences.edit();
 
         StringBuilder boardString = new StringBuilder();
@@ -47,18 +55,22 @@ public class Cam2048Repository {
             }
         }
 
-        editor.putString(SAVED_BOARD_KEY_PREFIX + currentUser.getUid(), boardString.toString());
-        editor.putInt(SAVED_SCORE_KEY_PREFIX + currentUser.getUid(), score);
+        editor.putString(SAVED_BOARD_KEY_PREFIX + user.getUid(), boardString.toString());
+        editor.putInt(SAVED_SCORE_KEY_PREFIX + user.getUid(), score);
         editor.apply();
     }
 
     public int[][] getSavedBoard() {
-        if (currentUser == null) return null;
-        String boardString = sharedPreferences.getString(SAVED_BOARD_KEY_PREFIX + currentUser.getUid(), null);
-        if (boardString == null || boardString.isEmpty()) return null;
+        FirebaseUser user = getCurrentUser();
+        if (user == null)
+            return null;
+        String boardString = sharedPreferences.getString(SAVED_BOARD_KEY_PREFIX + user.getUid(), null);
+        if (boardString == null || boardString.isEmpty())
+            return null;
 
         String[] values = boardString.split(",");
-        if (values.length != 16) return null;
+        if (values.length != 16)
+            return null;
 
         int[][] board = new int[4][4];
         for (int i = 0; i < 4; i++) {
@@ -70,15 +82,29 @@ public class Cam2048Repository {
     }
 
     public int getSavedScore() {
-        if (currentUser == null) return -1;
-        return sharedPreferences.getInt(SAVED_SCORE_KEY_PREFIX + currentUser.getUid(), -1);
+        FirebaseUser user = getCurrentUser();
+        if (user == null)
+            return -1;
+        return sharedPreferences.getInt(SAVED_SCORE_KEY_PREFIX + user.getUid(), -1);
     }
 
     public void clearSavedState() {
-        if (currentUser == null) return;
+        FirebaseUser user = getCurrentUser();
+        if (user == null)
+            return;
         SharedPreferences.Editor editor = sharedPreferences.edit();
-        editor.remove(SAVED_BOARD_KEY_PREFIX + currentUser.getUid());
-        editor.remove(SAVED_SCORE_KEY_PREFIX + currentUser.getUid());
+        editor.remove(SAVED_BOARD_KEY_PREFIX + user.getUid());
+        editor.remove(SAVED_SCORE_KEY_PREFIX + user.getUid());
+        editor.apply();
+    }
+
+    public void clearHighScore() {
+        FirebaseUser user = getCurrentUser();
+        if (user == null)
+            return;
+        android.util.Log.d("Cam2048Repository", "Clearing high score for user: " + user.getUid());
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.remove(HIGH_SCORE_KEY_PREFIX + user.getUid());
         editor.apply();
     }
 }

--- a/app/src/main/java/com/appsters/unlimitedgames/games/interfaces/IGame.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/games/interfaces/IGame.java
@@ -1,0 +1,9 @@
+package com.appsters.unlimitedgames.games.interfaces;
+
+public interface IGame {
+    /**
+     * Clears all user-specific data for the game.
+     * This is called when the user logs out.
+     */
+    void clearUserData();
+}

--- a/app/src/main/java/com/appsters/unlimitedgames/games/maze/MazeGame.kt
+++ b/app/src/main/java/com/appsters/unlimitedgames/games/maze/MazeGame.kt
@@ -1,0 +1,11 @@
+package com.appsters.unlimitedgames.games.maze
+
+import android.content.Context
+import com.appsters.unlimitedgames.games.interfaces.IGame
+import com.appsters.unlimitedgames.games.maze.controller.RunManager
+
+class MazeGame(private val context: Context) : IGame {
+    override fun clearUserData() {
+        RunManager.clearAllData(context)
+    }
+}

--- a/app/src/main/java/com/appsters/unlimitedgames/games/sudoku/SudokuGame.kt
+++ b/app/src/main/java/com/appsters/unlimitedgames/games/sudoku/SudokuGame.kt
@@ -1,0 +1,12 @@
+package com.appsters.unlimitedgames.games.sudoku
+
+import android.content.Context
+import com.appsters.unlimitedgames.games.interfaces.IGame
+import com.appsters.unlimitedgames.games.sudoku.repository.SudokuRepository
+
+class SudokuGame(private val context: Context) : IGame {
+    override fun clearUserData() {
+        val repository = SudokuRepository(context)
+        repository.clearAllData()
+    }
+}

--- a/app/src/main/java/com/appsters/unlimitedgames/games/whackamole/WhackAMoleGame.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/games/whackamole/WhackAMoleGame.java
@@ -1,0 +1,20 @@
+package com.appsters.unlimitedgames.games.whackamole;
+
+import android.content.Context;
+import com.appsters.unlimitedgames.games.interfaces.IGame;
+import com.appsters.unlimitedgames.games.whackamole.repository.SharedPrefGameRepository;
+
+public class WhackAMoleGame implements IGame {
+    private final Context context;
+
+    public WhackAMoleGame(Context context) {
+        this.context = context;
+    }
+
+    @Override
+    public void clearUserData() {
+        android.content.SharedPreferences prefs = context.getSharedPreferences("WhackAMolePrefs", Context.MODE_PRIVATE);
+        SharedPrefGameRepository repository = new SharedPrefGameRepository(prefs);
+        repository.clearData();
+    }
+}

--- a/app/src/main/res/drawable/ic_profile.xml
+++ b/app/src/main/res/drawable/ic_profile.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24.0"
     android:viewportHeight="24.0">
     <path
-        android:fillColor="#FF000000"
+        android:fillColor="#FFFFFFFF"
         android:pathData="M12,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zm0,2c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z" />
 </vector>

--- a/app/src/main/res/layout/fragment_find_friends.xml
+++ b/app/src/main/res/layout/fragment_find_friends.xml
@@ -17,7 +17,8 @@
             android:layout_height="48dp"
             android:hint="Search username..."
             android:padding="12dp"
-            android:background="@android:drawable/editbox_background_normal"
+            android:textColor="?android:attr/textColorPrimary"
+            android:textColorHint="?android:attr/textColorHint"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/item_find_friend.xml
+++ b/app/src/main/res/layout/item_find_friend.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:padding="12dp"
@@ -12,6 +13,7 @@
         android:layout_height="wrap_content"
         android:textSize="18sp"
         android:textStyle="bold"
+        android:textColor="?android:attr/textColorPrimary"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toStartOf="@id/btnAddFriend"
         app:layout_constraintTop_toTopOf="parent"
@@ -22,7 +24,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:textSize="14sp"
-        android:textColor="@android:color/darker_gray"
+        android:textColor="?android:attr/textColorSecondary"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tvUsername"
         app:layout_constraintEnd_toStartOf="@id/btnAddFriend"

--- a/app/src/main/res/layout/item_friend.xml
+++ b/app/src/main/res/layout/item_friend.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -39,7 +40,7 @@
             android:layout_marginStart="16dp"
             android:textSize="18sp"
             android:textStyle="bold"
-            android:textColor="@android:color/black"
+            android:textColor="?android:attr/textColorPrimary"
             tools:text="JohnDoe" />
 
     </LinearLayout>


### PR DESCRIPTION
closes #39 closes #36

Introduces a `GameCleanupManager` to clear all game-related user data upon logout. This ensures that when a user signs out, their progress and saved states from games like Sudoku, 2048, Maze, and Whack-a-Mole are wiped from the device.

- **Game Cleanup Abstraction**:
    - Adds a new `IGame` interface with a `clearUserData()` method.
    - Creates `GameCleanupManager` to iterate through a list of `IGame` implementations and trigger their cleanup logic.
    - Implements the `IGame` interface for `SudokuGame`, `Game2048Game`, `MazeGame`, and `WhackAMoleGame`, which now handle their own data deletion.

- **Auth ViewModel Integration**:
    - Creates `AuthViewModelFactory` to inject the `GameCleanupManager` into the `AuthViewModel`.
    - `AuthViewModel` now calls `gameCleanupManager.clearAllGameData()` within its `logout()` method.
    - Updates `LoginFragment`, `SignUpFragment`, `ProfileFragment`, and `MainActivity` to use the new `AuthViewModelFactory`.

- **Friend Search and UI**:
    - Replaces client-side friend search with a server-side `searchNewFriends` query in `FriendRepository` for better performance and privacy.
    - Updates UI text colors in `find_friends`, `item_friend`, and `item_find_friend` layouts to use theme attributes (`textColorPrimary`, `textColorHint`, etc.) for better dark mode compatibility.