### PR TITLE
feat: Implement privacy controls and offline score submission

### DIFF
--- a/app/src/main/java/com/appsters/unlimitedgames/app/data/GameDataSource.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/app/data/GameDataSource.java
@@ -87,5 +87,10 @@ public class GameDataSource {
                                 android.content.Context.MODE_PRIVATE);
                 new com.appsters.unlimitedgames.games.whackamole.repository.SharedPrefGameRepository(whackPrefs)
                                 .clearData();
+
+                // Clear Soccer Separation Game Data
+                new com.appsters.unlimitedgames.games.soccerseparationgame.repository.SoccerSeparationGameRepository(
+                                context)
+                                .clearUserData();
         }
 }

--- a/app/src/main/java/com/appsters/unlimitedgames/app/data/model/Score.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/app/data/model/Score.java
@@ -10,18 +10,29 @@ public class Score {
     private int score;
     private long timestamp;
     private int rank;
+    private com.appsters.unlimitedgames.app.util.Privacy privacy; // Denormalized privacy
 
     public Score() {
         this.timestamp = System.currentTimeMillis();
+        this.privacy = com.appsters.unlimitedgames.app.util.Privacy.PUBLIC; // Default
     }
 
-    public Score(String scoreId, String userId, String username, GameType gameType, int score) {
+    public Score(String scoreId, String userId, String username, GameType gameType, int score,
+            com.appsters.unlimitedgames.app.util.Privacy privacy) {
         this.scoreId = scoreId;
         this.userId = userId;
         this.username = username;
         this.gameType = gameType;
         this.score = score;
         this.timestamp = System.currentTimeMillis();
+        this.privacy = privacy;
+    }
+
+    // Keep existing constructor for backward compatibility if needed, or update
+    // call sites.
+    // Ideally we update call sites, but overloading is safer for now.
+    public Score(String scoreId, String userId, String username, GameType gameType, int score) {
+        this(scoreId, userId, username, gameType, score, com.appsters.unlimitedgames.app.util.Privacy.PUBLIC);
     }
 
     public String getScoreId() {
@@ -78,5 +89,13 @@ public class Score {
 
     public void setRank(int rank) {
         this.rank = rank;
+    }
+
+    public com.appsters.unlimitedgames.app.util.Privacy getPrivacy() {
+        return privacy;
+    }
+
+    public void setPrivacy(com.appsters.unlimitedgames.app.util.Privacy privacy) {
+        this.privacy = privacy;
     }
 }

--- a/app/src/main/java/com/appsters/unlimitedgames/app/data/repository/FriendRepository.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/app/data/repository/FriendRepository.java
@@ -303,4 +303,32 @@ public class FriendRepository {
         });
     }
 
+    public void deleteAllFriends(String userId, OnCompleteListener<Void> listener) {
+        db.collection(COLLECTION)
+                .where(Filter.or(
+                        Filter.equalTo("fromUserId", userId),
+                        Filter.equalTo("toUserId", userId)))
+                .get()
+                .addOnCompleteListener(task -> {
+                    if (task.isSuccessful() && task.getResult() != null) {
+                        List<com.google.android.gms.tasks.Task<Void>> deletes = new ArrayList<>();
+                        for (QueryDocumentSnapshot doc : task.getResult()) {
+                            deletes.add(doc.getReference().delete());
+                        }
+
+                        if (deletes.isEmpty()) {
+                            listener.onComplete(com.google.android.gms.tasks.Tasks.forResult(null));
+                        } else {
+                            com.google.android.gms.tasks.Tasks.whenAll(deletes)
+                                    .addOnCompleteListener(listener);
+                        }
+                    } else {
+                        listener.onComplete(
+                                com.google.android.gms.tasks.Tasks.forException(
+                                        task.getException() != null ? task.getException()
+                                                : new Exception("Failed to load friend documents")));
+                    }
+                });
+    }
+
 }

--- a/app/src/main/java/com/appsters/unlimitedgames/app/data/repository/LeaderboardRepository.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/app/data/repository/LeaderboardRepository.java
@@ -2,6 +2,7 @@ package com.appsters.unlimitedgames.app.data.repository;
 
 import com.appsters.unlimitedgames.app.data.model.Friend;
 import com.appsters.unlimitedgames.app.data.model.Score;
+import com.appsters.unlimitedgames.app.data.model.User;
 import com.appsters.unlimitedgames.app.util.GameType;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
@@ -19,18 +20,183 @@ import java.util.stream.Collectors;
 public class LeaderboardRepository {
     private FirebaseFirestore db;
     private FriendRepository friendRepository;
+    private final android.content.Context context;
+    private final com.google.gson.Gson gson;
+    private static final String PENDING_SCORES_PREF = "PendingScores";
 
-    public LeaderboardRepository() {
+    public LeaderboardRepository(android.content.Context context) {
+        this.context = context.getApplicationContext();
         this.db = FirebaseFirestore.getInstance();
         this.friendRepository = new FriendRepository();
+        this.gson = new com.google.gson.Gson();
+
+        retryPendingScores();
     }
 
-    public void getGlobalLeaderboard(GameType gameType, int limit, OnCompleteListener<List<Score>> listener) {
+    public void getGlobalLeaderboard(String currentUserId, GameType gameType, int limit,
+            OnCompleteListener<List<Score>> listener) {
+        // 1. Fetch scores
+        OnCompleteListener<List<Score>> scoresListener = (isSuccess, scores, error) -> {
+            if (!isSuccess || scores == null) {
+                listener.onComplete(false, null, error);
+                return;
+            }
+
+            // 2. Fetch current user's friends to check for FRIENDS_ONLY access
+            friendRepository.getFriends(currentUserId, friendsTask -> {
+                List<String> friendIds = new ArrayList<>();
+                if (friendsTask.isSuccessful() && friendsTask.getResult() != null) {
+                    for (Friend f : friendsTask.getResult()) {
+                        friendIds.add(f.getFromUserId().equals(currentUserId) ? f.getToUserId() : f.getFromUserId());
+                    }
+                }
+                friendIds.add(currentUserId); // I am my own friend for visibility
+
+                // 3. Identify scores with missing privacy (Legacy Data)
+                final List<Score> scoresWithPrivacy = new ArrayList<>();
+                List<String> userIdsToFetch = new ArrayList<>();
+
+                for (Score s : scores) {
+                    if (s.getPrivacy() == null) {
+                        userIdsToFetch.add(s.getUserId());
+                    }
+                }
+
+                // Helper to finalize filtering
+                OnCompleteListener<Map<String, User>> filterStep = (uSuccess, userMap, uError) -> {
+                    // 4. Filter scores using denormalized privacy data (or fetched user data)
+                    List<Score> filteredScores = new ArrayList<>();
+
+                    for (Score s : scores) {
+                        com.appsters.unlimitedgames.app.util.Privacy privacy = s.getPrivacy();
+
+                        // If null, look up in fetched map
+                        if (privacy == null && userMap != null) {
+                            User u = userMap.get(s.getUserId());
+                            if (u != null) {
+                                privacy = u.getPrivacy();
+                            }
+                        }
+
+                        // Default to PUBLIC only if we absolutely have no info (shouldn't happen if
+                        // user exists)
+                        // But if privacy is PRIVATE, it's not PUBLIC.
+                        if (privacy == null) {
+                            privacy = com.appsters.unlimitedgames.app.util.Privacy.PUBLIC;
+                        }
+
+                        boolean isPublic = privacy == com.appsters.unlimitedgames.app.util.Privacy.PUBLIC;
+                        boolean isFriendsOnly = privacy == com.appsters.unlimitedgames.app.util.Privacy.FRIENDS_ONLY;
+                        boolean isFriend = friendIds.contains(s.getUserId());
+
+                        // Show if Public OR (FriendsOnly AND I am a friend/self)
+                        if (isPublic || (isFriendsOnly && isFriend)) {
+                            filteredScores.add(s);
+                        }
+                    }
+
+                    // Re-rank
+                    for (int i = 0; i < filteredScores.size(); i++) {
+                        filteredScores.get(i).setRank(i + 1);
+                    }
+
+                    listener.onComplete(true, filteredScores, null);
+                };
+
+                // Execute fetch if needed
+                if (!userIdsToFetch.isEmpty()) {
+                    List<String> distinctIds = userIdsToFetch.stream().distinct().collect(Collectors.toList());
+                    fetchUsers(distinctIds, (uSuccess, uMap, uError) -> {
+                        // Even if fetch fails, we proceed with what we have (nulls becoming public per
+                        // default safety fallback, or empty)
+                        // Ideally we log error.
+                        filterStep.onComplete(uSuccess, uMap, uError);
+                    });
+                } else {
+                    filterStep.onComplete(true, new HashMap<>(), null);
+                }
+            });
+        };
+
         if (gameType == GameType.ALL) {
-            getAggregateLeaderboard(limit, listener);
+            getAggregateLeaderboard(limit, scoresListener);
         } else {
-            getSingleGameLeaderboard(gameType, limit, listener);
+            getSingleGameLeaderboard(gameType, limit, scoresListener);
         }
+    }
+
+    // Helper to fetch multiple users. No longer used for leaderboard filtering but
+    // kept for other uses if needed.
+    private void fetchUsers(List<String> userIds, OnCompleteListener<Map<String, User>> listener) {
+        if (userIds.isEmpty()) {
+            listener.onComplete(true, new HashMap<>(), null);
+            return;
+        }
+
+        // Chunking
+        List<com.google.android.gms.tasks.Task<QuerySnapshot>> tasks = new ArrayList<>();
+        int batchSize = 10;
+        for (int i = 0; i < userIds.size(); i += batchSize) {
+            List<String> batch = userIds.subList(i, Math.min(i + batchSize, userIds.size()));
+            tasks.add(db.collection("users").whereIn("uid", batch).get());
+        }
+
+        com.google.android.gms.tasks.Tasks.whenAllSuccess(tasks).addOnCompleteListener(task -> {
+            if (task.isSuccessful() && task.getResult() != null) {
+                Map<String, User> userMap = new HashMap<>();
+                for (Object obj : task.getResult()) {
+                    QuerySnapshot snap = (QuerySnapshot) obj;
+                    for (DocumentSnapshot doc : snap) {
+                        User u = doc.toObject(User.class);
+                        if (u != null) {
+                            userMap.put(u.getUserId(), u);
+                        }
+                    }
+                }
+                listener.onComplete(true, userMap, null);
+            } else {
+                listener.onComplete(false, null, task.getException());
+            }
+        });
+    }
+
+    public void updateUserPrivacy(String userId, com.appsters.unlimitedgames.app.util.Privacy newPrivacy,
+            OnCompleteListener<Void> listener) {
+        db.collection("scores")
+                .whereEqualTo("userId", userId)
+                .get()
+                .addOnCompleteListener(task -> {
+                    if (task.isSuccessful() && task.getResult() != null) {
+                        com.google.firebase.firestore.WriteBatch batch = db.batch();
+                        for (DocumentSnapshot doc : task.getResult()) {
+                            batch.update(doc.getReference(), "privacy", newPrivacy);
+                        }
+                        batch.commit().addOnCompleteListener(batchTask -> {
+                            listener.onComplete(batchTask.isSuccessful(), null, batchTask.getException());
+                        });
+                    } else {
+                        listener.onComplete(false, null, task.getException());
+                    }
+                });
+    }
+
+    public void deleteAllUserScores(String userId, OnCompleteListener<Void> listener) {
+        db.collection("scores")
+                .whereEqualTo("userId", userId)
+                .get()
+                .addOnCompleteListener(task -> {
+                    if (task.isSuccessful() && task.getResult() != null) {
+                        com.google.firebase.firestore.WriteBatch batch = db.batch();
+                        for (DocumentSnapshot doc : task.getResult()) {
+                            batch.delete(doc.getReference());
+                        }
+                        batch.commit().addOnCompleteListener(batchTask -> {
+                            listener.onComplete(batchTask.isSuccessful(), null, batchTask.getException());
+                        });
+                    } else {
+                        listener.onComplete(false, null, task.getException());
+                    }
+                });
     }
 
     private void getSingleGameLeaderboard(GameType gameType, int limit, OnCompleteListener<List<Score>> listener) {
@@ -71,7 +237,8 @@ public class LeaderboardRepository {
                         .filter(s -> s.getGameType() != GameType.ALL)
                         .collect(Collectors.groupingBy(Score::getGameType));
 
-                scoresByGame.forEach((game, scores) -> scores.sort(Comparator.comparingInt(Score::getScore).reversed()));
+                scoresByGame
+                        .forEach((game, scores) -> scores.sort(Comparator.comparingInt(Score::getScore).reversed()));
 
                 Map<String, int[]> userRankStats = new HashMap<>();
                 Map<String, String> userIdToUsername = new HashMap<>();
@@ -98,17 +265,38 @@ public class LeaderboardRepository {
 
                     if (gamesPlayed > 0) {
                         int averageRank = totalRank / gamesPlayed;
+
+                        // Find privacy from one of the user's scores (assuming consistency)
+                        com.appsters.unlimitedgames.app.util.Privacy userPrivacy = com.appsters.unlimitedgames.app.util.Privacy.PUBLIC;
+                        // Try to find a non-null privacy
+                        for (Map.Entry<GameType, List<Score>> gameEntry : scoresByGame.entrySet()) {
+                            List<Score> sList = gameEntry.getValue();
+                            for (Score s : sList) {
+                                if (s.getUserId().equals(userId) && s.getPrivacy() != null) {
+                                    userPrivacy = s.getPrivacy();
+                                    break;
+                                }
+                            }
+                            // Optimization: if we found it effectively, break outer?
+                            // But strict inner loop check is fine.
+                        }
+
                         Score aggregateScore = new Score(
                                 "",
                                 userId,
                                 userIdToUsername.get(userId),
                                 GameType.ALL,
-                                averageRank
-                        );
+                                averageRank,
+                                userPrivacy);
                         aggregateLeaderboard.add(aggregateScore);
                     }
                 }
 
+                // For aggregate rank (average rank), lower is better?
+                // Original code sorted by score ASC? "Comparator.comparingInt(Score::getScore)"
+                // But Average Rank: 1 is better than 10.
+                // Score object usually holds "score". Here it holds "averageRank".
+                // So sorting by ASC is correct for rank.
                 aggregateLeaderboard.sort(Comparator.comparingInt(Score::getScore));
 
                 List<Score> finalList = aggregateLeaderboard.stream().limit(limit).collect(Collectors.toList());
@@ -121,29 +309,45 @@ public class LeaderboardRepository {
         });
     }
 
-
     public void getFriendsLeaderboard(String userId, GameType gameType, OnCompleteListener<List<Score>> listener) {
-        friendRepository.getFriends(userId, friendsTask -> {
-            if (!friendsTask.isSuccessful() || friendsTask.getResult() == null) {
-                listener.onComplete(false, null, friendsTask.getException());
+        // Reuse getGlobalLeaderboard logic which handles friends filtering now?
+        // Actually, getFriendsLeaderboard wants ONLY friends.
+        // getGlobalLeaderboard shows Public + Friends.
+        // So we can use getGlobalLeaderboard and then filter further?
+        // Or keep separate implementation?
+        // FriendsLeaderboard should show ALL friends, regardless of their privacy
+        // (usually friends see friends data).
+        // Let's rely on getGlobalLeaderboard('userId', ...) but filter specifically for
+        // friends list.
+
+        getGlobalLeaderboard(userId, gameType, 1000, (success, scores, err) -> {
+            if (!success) {
+                listener.onComplete(false, null, err);
                 return;
             }
 
-            List<Friend> friends = friendsTask.getResult();
-            List<String> friendIds = friends.stream()
-                    .map(friend -> friend.getFromUserId().equals(userId) ? friend.getToUserId() : friend.getFromUserId())
-                    .collect(Collectors.toList());
-            friendIds.add(userId);
-
-            getGlobalLeaderboard(gameType, 1000, (isSuccessful, allScores, e) -> {
-                if (isSuccessful) {
-                    List<Score> friendScores = allScores.stream()
-                            .filter(score -> friendIds.contains(score.getUserId()))
-                            .collect(Collectors.toList());
-                    listener.onComplete(true, friendScores, null);
-                } else {
-                    listener.onComplete(false, null, e);
+            friendRepository.getFriends(userId, friendsTask -> {
+                if (!friendsTask.isSuccessful()) {
+                    listener.onComplete(false, null, friendsTask.getException());
+                    return;
                 }
+
+                List<String> friendIds = new ArrayList<>();
+                for (Friend f : friendsTask.getResult()) {
+                    friendIds.add(f.getFromUserId().equals(userId) ? f.getToUserId() : f.getFromUserId());
+                }
+                friendIds.add(userId);
+
+                List<Score> friendScores = scores.stream()
+                        .filter(s -> friendIds.contains(s.getUserId()))
+                        .collect(Collectors.toList());
+
+                // Re-rank
+                for (int i = 0; i < friendScores.size(); i++) {
+                    friendScores.get(i).setRank(i + 1);
+                }
+
+                listener.onComplete(true, friendScores, null);
             });
         });
     }
@@ -162,6 +366,9 @@ public class LeaderboardRepository {
 
                     if (existingScore != null && newScore.getScore() > existingScore.getScore()) {
                         existingDoc.getReference().set(newScore).addOnCompleteListener(updateTask -> {
+                            if (!updateTask.isSuccessful()) {
+                                savePendingScore(newScore);
+                            }
                             listener.onComplete(updateTask.isSuccessful(), null, updateTask.getException());
                         });
                     } else {
@@ -169,13 +376,54 @@ public class LeaderboardRepository {
                     }
                 } else {
                     db.collection("scores").add(newScore).addOnCompleteListener(createTask -> {
+                        if (!createTask.isSuccessful()) {
+                            savePendingScore(newScore);
+                        }
                         listener.onComplete(createTask.isSuccessful(), null, createTask.getException());
                     });
                 }
             } else {
+                savePendingScore(newScore);
                 listener.onComplete(false, null, task.getException());
             }
         });
+    }
+
+    private void savePendingScore(Score score) {
+        android.content.SharedPreferences prefs = context.getSharedPreferences(PENDING_SCORES_PREF,
+                android.content.Context.MODE_PRIVATE);
+        String key = score.getUserId() + "_" + score.getGameType();
+        // Check if we have a better score pending
+        String existingJson = prefs.getString(key, null);
+        if (existingJson != null) {
+            Score existing = gson.fromJson(existingJson, Score.class);
+            if (existing.getScore() >= score.getScore()) {
+                return; // Already have a better or equal pending score
+            }
+        }
+
+        prefs.edit().putString(key, gson.toJson(score)).apply();
+    }
+
+    public void retryPendingScores() {
+        android.content.SharedPreferences prefs = context.getSharedPreferences(PENDING_SCORES_PREF,
+                android.content.Context.MODE_PRIVATE);
+        Map<String, ?> allPending = prefs.getAll();
+
+        for (Map.Entry<String, ?> entry : allPending.entrySet()) {
+            if (entry.getValue() instanceof String) {
+                String json = (String) entry.getValue();
+                Score score = gson.fromJson(json, Score.class);
+
+                // Try submitting again. If successful, remove from prefs.
+                // We pass a listener that removes it on success.
+                submitScore(score, (isSuccess, result, e) -> {
+                    if (isSuccess) {
+                        prefs.edit().remove(entry.getKey()).apply();
+                    }
+                });
+            }
+        }
     }
 
     public interface OnCompleteListener<T> {

--- a/app/src/main/java/com/appsters/unlimitedgames/app/ui/leaderboard/LeaderboardViewModel.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/app/ui/leaderboard/LeaderboardViewModel.java
@@ -11,7 +11,7 @@ import com.google.firebase.auth.FirebaseAuth;
 
 import java.util.List;
 
-public class LeaderboardViewModel extends ViewModel {
+public class LeaderboardViewModel extends androidx.lifecycle.AndroidViewModel {
 
     private final LeaderboardRepository leaderboardRepository;
     private final MutableLiveData<List<Score>> leaderboard = new MutableLiveData<>();
@@ -20,8 +20,9 @@ public class LeaderboardViewModel extends ViewModel {
     private GameType selectedGame = GameType.ALL;
     private boolean showFriendsOnly = false;
 
-    public LeaderboardViewModel() {
-        leaderboardRepository = new LeaderboardRepository();
+    public LeaderboardViewModel(android.app.Application application) {
+        super(application);
+        leaderboardRepository = new LeaderboardRepository(application);
     }
 
     public LiveData<List<Score>> getLeaderboard() {
@@ -50,7 +51,7 @@ public class LeaderboardViewModel extends ViewModel {
                 }
             });
         } else {
-            leaderboardRepository.getGlobalLeaderboard(selectedGame, 100, (isSuccessful, result, e) -> {
+            leaderboardRepository.getGlobalLeaderboard(userId, selectedGame, 100, (isSuccessful, result, e) -> {
                 isLoading.setValue(false);
                 if (isSuccessful) {
                     leaderboard.setValue(result);

--- a/app/src/main/java/com/appsters/unlimitedgames/games/game2048/Game2048Fragment.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/games/game2048/Game2048Fragment.java
@@ -25,18 +25,20 @@ public class Game2048Fragment extends Fragment {
     private FragmentGame2048Binding binding;
     private Game2048ViewModel viewModel;
     private TextView[][] tiles;
-    private GestureDetectorCompat gestureDetector;
+    private GestureDetector gestureDetector;
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         viewModel = new ViewModelProvider(this).get(Game2048ViewModel.class);
-        gestureDetector = new GestureDetectorCompat(requireContext(), new SwipeListener());
+        gestureDetector = new GestureDetector(requireContext(), new SwipeListener(),
+                new android.os.Handler(android.os.Looper.getMainLooper()));
     }
 
     @Nullable
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+            @Nullable Bundle savedInstanceState) {
         binding = FragmentGame2048Binding.inflate(inflater, container, false);
         binding.setViewModel(viewModel);
         binding.setLifecycleOwner(getViewLifecycleOwner());
@@ -47,13 +49,14 @@ public class Game2048Fragment extends Fragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        binding.gameBoard.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
-            @Override
-            public void onGlobalLayout() {
-                binding.gameBoard.getViewTreeObserver().removeOnGlobalLayoutListener(this);
-                initializeBoard();
-            }
-        });
+        binding.gameBoard.getViewTreeObserver()
+                .addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+                    @Override
+                    public void onGlobalLayout() {
+                        binding.gameBoard.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                        initializeBoard();
+                    }
+                });
 
         viewModel.board.observe(getViewLifecycleOwner(), this::updateBoard);
         viewModel.gameOver.observe(getViewLifecycleOwner(), isGameOver -> {
@@ -83,9 +86,8 @@ public class Game2048Fragment extends Fragment {
                 TextView tile = new TextView(requireContext());
 
                 GridLayout.LayoutParams params = new GridLayout.LayoutParams(
-                    GridLayout.spec(i, 1f),
-                    GridLayout.spec(j, 1f)
-                );
+                        GridLayout.spec(i, 1f),
+                        GridLayout.spec(j, 1f));
                 params.width = 0;
                 params.height = 0;
                 params.setMargins(margin, margin, margin, margin);
@@ -101,7 +103,8 @@ public class Game2048Fragment extends Fragment {
     }
 
     private void updateBoard(int[][] board) {
-        if (board == null || tiles == null) return;
+        if (board == null || tiles == null)
+            return;
         for (int i = 0; i < 4; i++) {
             for (int j = 0; j < 4; j++) {
                 if (tiles[i][j] != null) {
@@ -123,18 +126,30 @@ public class Game2048Fragment extends Fragment {
 
     private int getTileColor(int value) {
         switch (value) {
-            case 2: return Color.parseColor("#EEE4DA");
-            case 4: return Color.parseColor("#EDE0C8");
-            case 8: return Color.parseColor("#F2B179");
-            case 16: return Color.parseColor("#F59563");
-            case 32: return Color.parseColor("#F67C5F");
-            case 64: return Color.parseColor("#F65E3B");
-            case 128: return Color.parseColor("#EDCF72");
-            case 256: return Color.parseColor("#EDCC61");
-            case 512: return Color.parseColor("#EDC850");
-            case 1024: return Color.parseColor("#EDC53F");
-            case 2048: return Color.parseColor("#EDC22E");
-            default: return Color.parseColor("#CDC1B4");
+            case 2:
+                return Color.parseColor("#EEE4DA");
+            case 4:
+                return Color.parseColor("#EDE0C8");
+            case 8:
+                return Color.parseColor("#F2B179");
+            case 16:
+                return Color.parseColor("#F59563");
+            case 32:
+                return Color.parseColor("#F67C5F");
+            case 64:
+                return Color.parseColor("#F65E3B");
+            case 128:
+                return Color.parseColor("#EDCF72");
+            case 256:
+                return Color.parseColor("#EDCC61");
+            case 512:
+                return Color.parseColor("#EDC850");
+            case 1024:
+                return Color.parseColor("#EDC53F");
+            case 2048:
+                return Color.parseColor("#EDC22E");
+            default:
+                return Color.parseColor("#CDC1B4");
         }
     }
 

--- a/app/src/main/java/com/appsters/unlimitedgames/games/game2048/Game2048ViewModel.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/games/game2048/Game2048ViewModel.java
@@ -39,7 +39,7 @@ public class Game2048ViewModel extends AndroidViewModel {
     public Game2048ViewModel(Application application) {
         super(application);
         repository = new Cam2048Repository(application);
-        leaderboardRepository = new LeaderboardRepository();
+        leaderboardRepository = new LeaderboardRepository(application);
         userRepository = new UserRepository();
         _highScore.setValue(repository.getHighScore());
         loadGame();
@@ -99,7 +99,8 @@ public class Game2048ViewModel extends AndroidViewModel {
 
         if (moved) {
             Integer currentScore = _score.getValue();
-            if (currentScore == null) currentScore = 0;
+            if (currentScore == null)
+                currentScore = 0;
             _score.setValue(currentScore + moveScore);
             addRandomTile();
             checkGameOver();
@@ -148,11 +149,16 @@ public class Game2048ViewModel extends AndroidViewModel {
 
     private int getRotationsForDirection(int direction) {
         switch (direction) {
-            case 0: return 0; // Left
-            case 1: return 1; // Up
-            case 2: return 2; // Right
-            case 3: return 3; // Down
-            default: return 0;
+            case 0:
+                return 0; // Left
+            case 1:
+                return 1; // Up
+            case 2:
+                return 2; // Right
+            case 3:
+                return 3; // Down
+            default:
+                return 0;
         }
     }
 
@@ -161,7 +167,7 @@ public class Game2048ViewModel extends AndroidViewModel {
         for (int i = 0; i < SIZE; i++) {
             for (int j = 0; j < SIZE; j++) {
                 if (boardArray[i][j] == 0) {
-                    emptyTiles.add(new int[]{i, j});
+                    emptyTiles.add(new int[] { i, j });
                 }
             }
         }
@@ -175,8 +181,8 @@ public class Game2048ViewModel extends AndroidViewModel {
         for (int i = 0; i < SIZE; i++) {
             for (int j = 0; j < SIZE; j++) {
                 if (boardArray[i][j] == 0 ||
-                    (i < SIZE - 1 && boardArray[i][j] == boardArray[i + 1][j]) ||
-                    (j < SIZE - 1 && boardArray[i][j] == boardArray[i][j + 1])) {
+                        (i < SIZE - 1 && boardArray[i][j] == boardArray[i + 1][j]) ||
+                        (j < SIZE - 1 && boardArray[i][j] == boardArray[i][j + 1])) {
                     _gameOver.postValue(false);
                     return;
                 }
@@ -196,7 +202,8 @@ public class Game2048ViewModel extends AndroidViewModel {
 
     private void submitScoreToLeaderboard(int score) {
         String userId = FirebaseAuth.getInstance().getUid();
-        if (userId == null) return;
+        if (userId == null)
+            return;
 
         userRepository.getUser(userId, task -> {
             if (task.isSuccessful() && task.getResult() != null) {

--- a/app/src/main/java/com/appsters/unlimitedgames/games/maze/MazeViewModel.kt
+++ b/app/src/main/java/com/appsters/unlimitedgames/games/maze/MazeViewModel.kt
@@ -9,7 +9,7 @@ import com.appsters.unlimitedgames.games.maze.controller.RunManager
 import com.appsters.unlimitedgames.games.maze.model.Maze
 import com.google.firebase.auth.FirebaseAuth
 
-class MazeViewModel : ViewModel() {
+class MazeViewModel(application: android.app.Application) : androidx.lifecycle.AndroidViewModel(application) {
 
     var maze: Maze? = null
         private set
@@ -58,7 +58,7 @@ class MazeViewModel : ViewModel() {
     private val _currentRound = androidx.lifecycle.MutableLiveData<Int>(1)
     val currentRound: androidx.lifecycle.LiveData<Int> = _currentRound
 
-    private val leaderboardRepository = LeaderboardRepository()
+    private val leaderboardRepository = LeaderboardRepository(application)
     private val userRepository = UserRepository()
     private var scoreSubmitted = false
 
@@ -430,7 +430,7 @@ class MazeViewModel : ViewModel() {
                 val user = task.result
                 if (user != null) {
                     val username = user.username
-                    val scoreObject = Score(null, userId, username, GameType.MAZE, score)
+                    val scoreObject = Score(null, userId, username, GameType.MAZE, score, user.privacy)
                     leaderboardRepository.submitScore(scoreObject) { _, _, _ ->
                         // Optionally handle success or failure
                     }

--- a/app/src/main/java/com/appsters/unlimitedgames/games/soccerseparationgame/SoccerSeparationGameFragment.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/games/soccerseparationgame/SoccerSeparationGameFragment.java
@@ -41,8 +41,7 @@ public class SoccerSeparationGameFragment extends Fragment {
     public View onCreateView(
             @NonNull LayoutInflater inflater,
             @Nullable ViewGroup container,
-            @Nullable Bundle savedInstanceState
-    ) {
+            @Nullable Bundle savedInstanceState) {
 
         View v = inflater.inflate(R.layout.fragment_soccer_separation_game, container, false);
 
@@ -90,7 +89,8 @@ public class SoccerSeparationGameFragment extends Fragment {
     }
 
     private void updateUI() {
-        if (isShowingFeedback) return;
+        if (isShowingFeedback)
+            return;
 
         Boolean isLoading = vm.getLoading().getValue();
         Boolean isGameOver = vm.getGameOver().getValue();
@@ -107,7 +107,8 @@ public class SoccerSeparationGameFragment extends Fragment {
             return;
         }
 
-        if (questionsList != null && !questionsList.isEmpty() && currentIndex != null && currentIndex < questionsList.size()) {
+        if (questionsList != null && !questionsList.isEmpty() && currentIndex != null
+                && currentIndex < questionsList.size()) {
             showPlayingUI();
             return;
         }
@@ -154,21 +155,22 @@ public class SoccerSeparationGameFragment extends Fragment {
         tvPlayer2.setText(q.player2.name);
 
         for (int i = 0; i < choiceButtons.length; i++) {
-                SeparationQuestion.Player p = q.choices1.get(i);
-                Button b = choiceButtons[i];
+            SeparationQuestion.Player p = q.choices1.get(i);
+            Button b = choiceButtons[i];
 
-                b.setVisibility(View.VISIBLE);
-                b.setEnabled(true);
-                b.setText(p.name);
-                b.setTextSize(18);
-                b.setTextColor(requireContext().getColor(R.color.separation_game_text));
-                b.setBackgroundTintList(requireContext().getColorStateList(R.color.separation_game_button));
-                b.setOnClickListener(v -> {
-                    if (isAnswered) return; // Prevent multiple clicks
-                    isAnswered = true;
-                    selectedAnswerId = p.id;
-                    vm.answer(p.id);
-                });
+            b.setVisibility(View.VISIBLE);
+            b.setEnabled(true);
+            b.setText(p.name);
+            b.setTextSize(18);
+            b.setTextColor(requireContext().getColor(R.color.separation_game_text));
+            b.setBackgroundTintList(requireContext().getColorStateList(R.color.separation_game_button));
+            b.setOnClickListener(v -> {
+                if (isAnswered)
+                    return; // Prevent multiple clicks
+                isAnswered = true;
+                selectedAnswerId = p.id;
+                vm.answer(p.id);
+            });
         }
     }
 
@@ -216,31 +218,34 @@ public class SoccerSeparationGameFragment extends Fragment {
         tvResult.setPadding(32, 32, 32, 32);
 
         btnRestart.setVisibility(View.VISIBLE);
+
+        vm.submitScore();
     }
 
     private void showAnswerFeedback(boolean isCorrect) {
         isShowingFeedback = true;
         SeparationQuestion q = vm.getCurrentQuestion();
-        if (q == null) return;
+        if (q == null)
+            return;
 
         // Highlight the buttons to show correct/incorrect
         for (int i = 0; i < choiceButtons.length; i++) {
-                Button b = choiceButtons[i];
-                SeparationQuestion.Player p = q.choices1.get(i);
+            Button b = choiceButtons[i];
+            SeparationQuestion.Player p = q.choices1.get(i);
 
-                if (p.id.equals(q.correct1.id)) {
-                    // This is the correct answer - always show in green
-                    b.setBackgroundTintList(requireContext().getColorStateList(R.color.separation_game_correct));
-                    b.setTextSize(22);
-                    b.setTextColor(requireContext().getColor(R.color.separation_game_text));
-                } else if (p.id.equals(selectedAnswerId)) {
-                    // User selected this wrong answer - show in red
-                    b.setBackgroundTintList(requireContext().getColorStateList(R.color.separation_game_wrong));
-                    b.setTextColor(requireContext().getColor(R.color.separation_game_text));
-                } else {
-                    // Other buttons - grey out
-                    b.setBackgroundTintList(requireContext().getColorStateList(R.color.separation_game_button_pressed));
-                }
+            if (p.id.equals(q.correct1.id)) {
+                // This is the correct answer - always show in green
+                b.setBackgroundTintList(requireContext().getColorStateList(R.color.separation_game_correct));
+                b.setTextSize(22);
+                b.setTextColor(requireContext().getColor(R.color.separation_game_text));
+            } else if (p.id.equals(selectedAnswerId)) {
+                // User selected this wrong answer - show in red
+                b.setBackgroundTintList(requireContext().getColorStateList(R.color.separation_game_wrong));
+                b.setTextColor(requireContext().getColor(R.color.separation_game_text));
+            } else {
+                // Other buttons - grey out
+                b.setBackgroundTintList(requireContext().getColorStateList(R.color.separation_game_button_pressed));
+            }
         }
 
         // Wait 1 seconds before moving to next question or ending game

--- a/app/src/main/java/com/appsters/unlimitedgames/games/soccerseparationgame/repository/SoccerSeparationGameRepository.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/games/soccerseparationgame/repository/SoccerSeparationGameRepository.java
@@ -15,6 +15,12 @@ public class SoccerSeparationGameRepository {
 
     private static final String TAG = "SeparationRepo";
 
+    private final android.content.SharedPreferences sharedPreferences;
+
+    public SoccerSeparationGameRepository(android.content.Context context) {
+        this.sharedPreferences = context.getSharedPreferences("SoccerGamePrefs", android.content.Context.MODE_PRIVATE);
+    }
+
     public void loadQuestions(BiConsumer<List<SeparationQuestion>, Exception> callback) {
 
         Log.d(TAG, "Loading questions…");
@@ -36,16 +42,14 @@ public class SoccerSeparationGameRepository {
                     Log.d(TAG, "Parsed " + parsed.size() + " questions");
 
                     callback.accept(parsed, null);
-                }
-        );
+                });
     }
 
     public void fetchTeammateQuestions(
             int steps,
             int numQuestions,
             int numOptions,
-            BiConsumer<String, Exception> callback
-    ) {
+            BiConsumer<String, Exception> callback) {
 
         String urlString = "http://sdmay26-37.ece.iastate.edu:8080/soccer/teammates/question"
                 + "?steps=" + steps
@@ -75,8 +79,7 @@ public class SoccerSeparationGameRepository {
                 }
 
                 BufferedReader reader = new BufferedReader(
-                        new InputStreamReader(connection.getInputStream())
-                );
+                        new InputStreamReader(connection.getInputStream()));
 
                 StringBuilder sb = new StringBuilder();
                 String line;
@@ -101,5 +104,20 @@ public class SoccerSeparationGameRepository {
             }
 
         }).start();
+    }
+
+    public void saveLocalHighScore(int score) {
+        int currentHigh = getLocalHighScore();
+        if (score > currentHigh) {
+            sharedPreferences.edit().putInt("high_score", score).apply();
+        }
+    }
+
+    public int getLocalHighScore() {
+        return sharedPreferences.getInt("high_score", 0);
+    }
+
+    public void clearUserData() {
+        sharedPreferences.edit().clear().apply();
     }
 }

--- a/app/src/main/java/com/appsters/unlimitedgames/games/sudoku/SudokuGameFragment.kt
+++ b/app/src/main/java/com/appsters/unlimitedgames/games/sudoku/SudokuGameFragment.kt
@@ -81,7 +81,7 @@ class SudokuGameFragment : Fragment(), SudokuBoardView.OnCellSelectedListener {
         }
 
         val repository = SudokuRepository(requireContext())
-        val factory = SudokuViewModelFactory(repository)
+        val factory = SudokuViewModelFactory(requireActivity().application, repository)
         viewModel = ViewModelProvider(this, factory)[SudokuViewModel::class.java]
     }
 

--- a/app/src/main/java/com/appsters/unlimitedgames/games/sudoku/SudokuViewModel.kt
+++ b/app/src/main/java/com/appsters/unlimitedgames/games/sudoku/SudokuViewModel.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.launch
  * Manages the game state, business logic, timer, and communication with the repository.
  * It exposes LiveData objects for the UI to observe.
  */
-class SudokuViewModel(private val repository: SudokuRepository) : ViewModel() {
+class SudokuViewModel(application: android.app.Application, private val repository: SudokuRepository) : androidx.lifecycle.AndroidViewModel(application) {
 
     private val _gameState = MutableLiveData<GameState>()
     val gameState: LiveData<GameState> = _gameState
@@ -43,7 +43,7 @@ class SudokuViewModel(private val repository: SudokuRepository) : ViewModel() {
     val gameCompletedEvent: LiveData<Score> = _gameCompletedEvent
 
     private lateinit var sudokuTimer: SudokuTimer
-    private val leaderboardRepository = LeaderboardRepository()
+    private val leaderboardRepository = LeaderboardRepository(getApplication())
     private val userRepository = UserRepository()
 
     /**
@@ -205,7 +205,7 @@ class SudokuViewModel(private val repository: SudokuRepository) : ViewModel() {
                 if (user != null) {
                     val username = user.username
                     val scoreObject = com.appsters.unlimitedgames.app.data.model.Score(
-                        null, userId, username, GameType.SUDOKU, score
+                        null, userId, username, GameType.SUDOKU, score, user.privacy
                     )
                     leaderboardRepository.submitScore(scoreObject) { _, _, _ ->
                         // Optionally handle success or failure
@@ -239,11 +239,11 @@ class SudokuViewModel(private val repository: SudokuRepository) : ViewModel() {
     }
 }
 
-class SudokuViewModelFactory(private val repository: SudokuRepository) : ViewModelProvider.Factory {
+class SudokuViewModelFactory(private val application: android.app.Application, private val repository: SudokuRepository) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(SudokuViewModel::class.java)) {
             @Suppress("UNCHECKED_CAST")
-            return SudokuViewModel(repository) as T
+            return SudokuViewModel(application, repository) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/app/src/main/java/com/appsters/unlimitedgames/games/whackamole/WhackAMoleGameActivity.kt
+++ b/app/src/main/java/com/appsters/unlimitedgames/games/whackamole/WhackAMoleGameActivity.kt
@@ -48,7 +48,7 @@ class WhackAMoleGameActivity : AppCompatActivity() {
         val prefs = getSharedPreferences("WhackAMolePrefs", MODE_PRIVATE)
         val repository = SharedPrefGameRepository(prefs)
         val scheduler = AndroidScheduler(mainLooper)
-        WhackAMoleGameViewModel(repository, scheduler)
+        WhackAMoleGameViewModel(application, repository, scheduler)
     }
 
     /**

--- a/app/src/main/res/drawable/bg_spinner_red_triangle.xml
+++ b/app/src/main/res/drawable/bg_spinner_red_triangle.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent" />
+            <stroke android:width="1dp" android:color="@color/dark_gray" />
+            <corners android:radius="4dp" />
+            <padding android:left="12dp" android:top="12dp" android:right="40dp"
+                android:bottom="12dp" />
+        </shape>
+    </item>
+    <item
+        android:drawable="@drawable/ic_red_triangle"
+        android:gravity="center_vertical|end"
+        android:right="8dp" />
+</layer-list>

--- a/app/src/main/res/drawable/ic_red_triangle.xml
+++ b/app/src/main/res/drawable/ic_red_triangle.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/red">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M7 10l5 5 5-5z" />
+</vector>

--- a/app/src/main/res/layout/fragment_leaderboard.xml
+++ b/app/src/main/res/layout/fragment_leaderboard.xml
@@ -21,6 +21,7 @@
             android:layout_marginStart="16dp"
             android:layout_marginTop="16dp"
             android:layout_marginEnd="16dp"
+            android:background="@drawable/bg_spinner_red_triangle"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
This commit introduces a major feature allowing users to control the privacy of their leaderboard scores (Public, Friends Only). It also adds an offline score submission mechanism to ensure scores are not lost due to network issues.

**Privacy Controls:**
- **Score Model:** The `Score` data model now includes a `privacy` field. This is denormalized from the user's profile settings at the time of score submission.
- **Leaderboard Filtering:** The `LeaderboardRepository` has been refactored to filter scores based on the viewer's relationship to the player and the score's privacy setting (Public or Friends Only).
- **Profile Integration:** Users can now set their leaderboard privacy from the Profile screen. Changing this setting triggers a background update of all their past scores.
- **Game ViewModels:** `SudokuViewModel`, `MazeViewModel`, `WhackAMoleGameViewModel`, and `SoccerSeparationGameViewModel` have been updated to include the user's privacy setting when creating and submitting a `Score` object.

**Offline Score Submission:**
- **Pending Scores:** The `LeaderboardRepository` now caches failed score submissions in `SharedPreferences`.
- **Automatic Retry:** The repository attempts to re-submit any pending scores upon application startup, ensuring data persistence even with intermittent connectivity.

**Account Deletion and Data Cleanup:**
- **Full Data Purge:** Deleting a user account now also removes all associated friend relationships and leaderboard scores from the database.
- **Game Data Cleanup:** Added cleanup logic for the Soccer Separation game data upon user logout.

**Game-Specific Enhancements:**
- **Soccer Separation Game:**
    - Implemented a streak bonus system, rewarding players with extra points for consecutive correct answers.
    - Scores are now submitted to the global leaderboard upon game completion.
    - Added local high score persistence.
- **2048 Game:** The `GestureDetector` is now deprecated and has been replaced with a non-deprecated version.

**Other Refinements:**
- All ViewModels now extend `AndroidViewModel` to have access to the application context, primarily for initializing repositories.
- Updated the leaderboard spinner UI with a custom background.