### PR TITLE
fix: Correctly display friend's username

### DIFF
--- a/app/src/main/java/com/appsters/unlimitedgames/app/ui/friends/FriendAdapter.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/app/ui/friends/FriendAdapter.java
@@ -18,8 +18,15 @@ public class FriendAdapter extends RecyclerView.Adapter<FriendAdapter.FriendVH> 
 
     private List<Friend> items = new ArrayList<>();
 
+    private final String currentUserId;
+
+    public FriendAdapter(String currentUserId) {
+        this.currentUserId = currentUserId;
+    }
+
     public void submitList(List<Friend> list) {
-        if (list == null) list = new ArrayList<>();
+        if (list == null)
+            list = new ArrayList<>();
         items = list;
         notifyDataSetChanged();
     }
@@ -29,8 +36,7 @@ public class FriendAdapter extends RecyclerView.Adapter<FriendAdapter.FriendVH> 
     public FriendVH onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         return new FriendVH(
                 LayoutInflater.from(parent.getContext())
-                        .inflate(R.layout.item_friend, parent, false)
-        );
+                        .inflate(R.layout.item_friend, parent, false));
     }
 
     @Override
@@ -39,10 +45,10 @@ public class FriendAdapter extends RecyclerView.Adapter<FriendAdapter.FriendVH> 
 
         // ✅ Display the OTHER user's username
         String displayName;
-        if (f.getFromUsername() != null && !f.getFromUsername().isEmpty()) {
-            displayName = f.getFromUsername();
-        } else {
+        if (f.getFromUserId() != null && f.getFromUserId().equals(currentUserId)) {
             displayName = f.getToUsername();
+        } else {
+            displayName = f.getFromUsername();
         }
 
         holder.name.setText(displayName);

--- a/app/src/main/java/com/appsters/unlimitedgames/app/ui/friends/FriendFragment.java
+++ b/app/src/main/java/com/appsters/unlimitedgames/app/ui/friends/FriendFragment.java
@@ -28,8 +28,8 @@ public class FriendFragment extends Fragment {
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater,
-                             @Nullable ViewGroup container,
-                             @Nullable Bundle savedInstanceState) {
+            @Nullable ViewGroup container,
+            @Nullable Bundle savedInstanceState) {
 
         binding = FragmentFriendsBinding.inflate(inflater, container, false);
         return binding.getRoot();
@@ -37,13 +37,15 @@ public class FriendFragment extends Fragment {
 
     @Override
     public void onViewCreated(@NonNull View view,
-                              @Nullable Bundle savedInstanceState) {
+            @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
         navController = Navigation.findNavController(view);
 
         viewModel = new ViewModelProvider(requireActivity()).get(FriendViewModel.class);
-        adapter = new FriendAdapter();
+
+        String userId = FirebaseAuth.getInstance().getUid();
+        adapter = new FriendAdapter(userId);
 
         binding.rvFriends.setLayoutManager(new LinearLayoutManager(requireContext()));
         binding.rvFriends.setAdapter(adapter);
@@ -51,7 +53,6 @@ public class FriendFragment extends Fragment {
         setupObservers();
         setupClickListeners();
 
-        String userId = FirebaseAuth.getInstance().getUid();
         if (userId != null) {
             viewModel.loadFriends(userId);
         }
@@ -63,9 +64,8 @@ public class FriendFragment extends Fragment {
             binding.emptyText.setVisibility(friends.isEmpty() ? View.VISIBLE : View.GONE);
         });
 
-        viewModel.getIsLoading().observe(getViewLifecycleOwner(), loading ->
-                binding.progressBar.setVisibility(loading ? View.VISIBLE : View.GONE)
-        );
+        viewModel.getIsLoading().observe(getViewLifecycleOwner(),
+                loading -> binding.progressBar.setVisibility(loading ? View.VISIBLE : View.GONE));
 
         viewModel.getErrorMessage().observe(getViewLifecycleOwner(), msg -> {
             if (msg != null && !msg.isEmpty()) {
@@ -75,13 +75,11 @@ public class FriendFragment extends Fragment {
     }
 
     private void setupClickListeners() {
-        binding.btnFindFriends.setOnClickListener(v ->
-                navController.navigate(R.id.action_friendsFragment_to_findFriendsFragment)
-        );
+        binding.btnFindFriends
+                .setOnClickListener(v -> navController.navigate(R.id.action_friendsFragment_to_findFriendsFragment));
 
-        binding.btnFriendRequests.setOnClickListener(v ->
-                navController.navigate(R.id.action_friendsFragment_to_friendRequestsFragment)
-        );
+        binding.btnFriendRequests
+                .setOnClickListener(v -> navController.navigate(R.id.action_friendsFragment_to_friendRequestsFragment));
     }
 
     @Override


### PR DESCRIPTION
Closes #62 

Ensures the friend list always shows the other user's username, not the current user's. This is fixed by passing the current user's ID to the `FriendAdapter` and adding logic to display the correct username from the `Friend` object.

- **`FriendFragment`**:
    - Retrieves the current user's ID from `FirebaseAuth`.
    - Passes the user ID to the `FriendAdapter` during its initialization.

- **`FriendAdapter`**:
    - Stores the current user's ID.
    - Updates logic to check if the `fromUserId` in a `Friend` object matches the current user's ID.
    - If it matches, it displays the `toUsername`; otherwise, it displays the `fromUsername`.